### PR TITLE
fix(python3.10): removes another pipe shortcut

### DIFF
--- a/runem/types.py
+++ b/runem/types.py
@@ -19,7 +19,7 @@ JobTags = typing.Set[JobTag]
 PhaseName = str
 OrderedPhases = typing.Tuple[PhaseName, ...]
 ReportName = str
-ReportUrl = str | pathlib.Path
+ReportUrl = typing.Union[str, pathlib.Path]
 ReportUrlInfo = typing.Tuple[ReportName, ReportUrl]
 ReportUrls = typing.List[ReportUrlInfo]
 


### PR DESCRIPTION
fixing python 3.10 support by removing another pipe shorthand