### PR TITLE
Chore/more typing strictness

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 
 exclude = ./docs
+strict = True  # Enable strict type checking (requires type annotations for functions)
 disallow_untyped_defs=True # Disallow functions and methods without type annotations (promotes type safety)
 check_untyped_defs=True # Enable checking for untyped definitions (helpful for catching missing type annotations)
 disallow_untyped_calls=True # Disallow function and method calls without type annotation

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,8 @@
 [mypy]
 
 exclude = ./docs
-; disallow_untyped_defs=True
-; check_untyped_defs=True
+; disallow_untyped_defs=True # Disallow functions and methods without type annotations (promotes type safety)
+; check_untyped_defs=True # Enable checking for untyped definitions (helpful for catching missing type annotations)
 show_error_codes=True
 mypy_path=python
 # disallow_typeddict_item=True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 
 exclude = ./docs
-; disallow_untyped_defs=True # Disallow functions and methods without type annotations (promotes type safety)
+disallow_untyped_defs=True # Disallow functions and methods without type annotations (promotes type safety)
 check_untyped_defs=True # Enable checking for untyped definitions (helpful for catching missing type annotations)
 show_error_codes=True
 mypy_path=python

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,10 +3,10 @@
 exclude = ./docs
 disallow_untyped_defs=True # Disallow functions and methods without type annotations (promotes type safety)
 check_untyped_defs=True # Enable checking for untyped definitions (helpful for catching missing type annotations)
+disallow_untyped_calls=True # Disallow function and method calls without type annotation
 show_error_codes=True
 mypy_path=python
 # disallow_typeddict_item=True
-# disallow_untyped_calls=True
 
 [mypy-termplotlib.*]
 # last checked .....not.

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 
 exclude = ./docs
 ; disallow_untyped_defs=True # Disallow functions and methods without type annotations (promotes type safety)
-; check_untyped_defs=True # Enable checking for untyped definitions (helpful for catching missing type annotations)
+check_untyped_defs=True # Enable checking for untyped definitions (helpful for catching missing type annotations)
 show_error_codes=True
 mypy_path=python
 # disallow_typeddict_item=True


### PR DESCRIPTION
### Summary :memo:
Makes mypy more pedantic & hopefully consistent

### Details
We were getting some inconsistent output from mypy i.e. change one file and another would produce type errors. 

This is an attempt to reduce surprises by making mypy stricter and consistent as functions that do not have typing should now error.

### Checks
- [x] Tested Changes
- [x] Stakeholder Approval
