### PR TITLE
chore(fix-mypy-config): ensures mypy catches all error (strict mode)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,18 +1,27 @@
 [mypy]
 
 exclude = ./docs
-strict = True  # Enable strict type checking (requires type annotations for functions)
-disallow_untyped_defs=True # Disallow functions and methods without type annotations (promotes type safety)
-check_untyped_defs=True # Enable checking for untyped definitions (helpful for catching missing type annotations)
-disallow_untyped_calls=True # Disallow function and method calls without type annotation
-show_error_codes=True
-mypy_path=python
-# disallow_typeddict_item=True
+# Enable strict type checking (requires type annotations for functions)
+strict = true
+
+# Disallow functions and methods without type annotations (promotes type safety)
+disallow_untyped_defs = true
+
+# Enable checking for untyped definitions (helpful for catching missing type annotations)
+check_untyped_defs = true
+
+# Disallow function and method calls without type annotation
+disallow_untyped_calls = true
+
+show_error_codes = true
+; mypy_path = python
+
+# disallow_typeddict_item = true
 
 [mypy-termplotlib.*]
 # last checked .....not.
-ignore_missing_imports = True
+ignore_missing_imports = true
 
 [mypy-halo.*]
 # last checked .....not.
-ignore_missing_imports = True
+ignore_missing_imports = true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,7 @@ flake8==6.1.0
 gitchangelog==3.0.4
 isort==5.12.0
 mkdocs==1.5.3
-mypy==1.7.0
+mypy==1.8.0
 pydocstyle==6.3.0
 pylint==3.0.2
 pylama==8.4.1

--- a/runem/cli.py
+++ b/runem/cli.py
@@ -4,5 +4,5 @@ import sys
 from runem.runem import timed_main
 
 
-def main():
+def main() -> None:
     timed_main(sys.argv)

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -34,14 +34,14 @@ def _parse_global_config(
     Returns the phases in the order we want to run them
     """
     options: OptionConfigs = ()
-    if "options" in global_config:
+    if "options" in global_config and global_config["options"]:
         options = tuple(
             option_serialised["option"]
             for option_serialised in global_config["options"]
         )
 
     file_filters: TagFileFilters = {}
-    if "files" in global_config:
+    if "files" in global_config and global_config["files"]:
         file_filter: TagFileFilterSerialised
         serialised_filters: typing.List[TagFileFilterSerialised] = global_config[
             "files"

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -107,11 +107,11 @@ def parse_config(config: Config, cfg_filepath: pathlib.Path) -> ConfigMetadata:
     for entry in config:
         # we apply a type-ignore here as we know (for now) that jobs have "job"
         # keys and global configs have "global" keys
-        isinstance_job: bool = "job" in entry  # type: ignore
+        isinstance_job: bool = "job" in entry
         if not isinstance_job:
             # we apply a type-ignore here as we know (for now) that jobs have "job"
             # keys and global configs have "global" keys
-            isinstance_global: bool = "config" in entry  # type: ignore
+            isinstance_global: bool = "config" in entry
             if isinstance_global:
                 if seen_global:
                     raise ValueError(

--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -9,7 +9,14 @@ from timeit import default_timer as timer
 from runem.config_metadata import ConfigMetadata
 from runem.job_wrapper_python import get_job_wrapper
 from runem.log import log
-from runem.types import FilePathList, FilePathListLookup, JobConfig, JobReturn, JobTags
+from runem.types import (
+    FilePathList,
+    FilePathListLookup,
+    JobConfig,
+    JobFunction,
+    JobReturn,
+    JobTags,
+)
 
 
 def job_execute_inner(
@@ -25,7 +32,7 @@ def job_execute_inner(
     if config_metadata.args.verbose:
         log(f"START: {label}")
     root_path: pathlib.Path = config_metadata.cfg_filepath.parent
-    function: typing.Callable
+    function: JobFunction
     job_tags: JobTags = set(job_config["when"]["tags"])
     os.chdir(root_path)
     function = get_job_wrapper(job_config, config_metadata.cfg_filepath)
@@ -57,11 +64,13 @@ def job_execute_inner(
         log(f"job: running {job_config['label']}")
     reports: JobReturn
     if "args" in func_signature.parameters:
-        reports = function(config_metadata.args, config_metadata.options, file_list)
+        reports = function(  # type: ignore  # FIXME: which function do we have?
+            config_metadata.args, config_metadata.options, file_list
+        )
     else:
         reports = function(
             options=config_metadata.options,  # type: ignore
-            file_list=file_list,  # type: ignore
+            file_list=file_list,
             procs=config_metadata.args.procs,
             root_path=root_path,
             verbose=config_metadata.args.verbose,

--- a/runem/run_command.py
+++ b/runem/run_command.py
@@ -18,7 +18,7 @@ class RunCommandUnhandledError(RuntimeError):
     pass
 
 
-def get_stdout(process: CompletedProcess, prefix: str) -> str:
+def get_stdout(process: CompletedProcess[bytes], prefix: str) -> str:
     """Gets stdout from the given process, handling badly configured process objects.
 
     Additionally prefixes each line of the output with a label.
@@ -36,7 +36,7 @@ def run_command(  # noqa: C901 # pylint: disable=too-many-branches
     cmd: typing.List[str],  # 'cmd' is the only thing that can't be optionally kwargs
     label: str,
     verbose: bool,
-    env_overrides: typing.Optional[dict] = None,
+    env_overrides: typing.Optional[typing.Dict[str, str]] = None,
     ignore_fails: bool = False,
     valid_exit_ids: typing.Optional[typing.Tuple[int, ...]] = None,
     **kwargs: typing.Any,
@@ -86,7 +86,7 @@ def run_command(  # noqa: C901 # pylint: disable=too-many-branches
 
     # init the process in case it throws for things like not being able to
     # convert the command to a list of strings.
-    process: typing.Optional[CompletedProcess] = None
+    process: typing.Optional[CompletedProcess[bytes]] = None
     try:
         process = subprocess_run(
             cmd,

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -80,7 +80,7 @@ def _determine_run_parameters(argv: typing.List[str]) -> ConfigMetadata:
 
 
 def _progress_updater(
-    label: str, running_jobs: typing.Dict[str, str], is_running: ValueProxy
+    label: str, running_jobs: typing.Dict[str, str], is_running: ValueProxy[bool]
 ) -> None:
     spinner = Halo(text="", spinner="dots")
     spinner.start()
@@ -126,7 +126,7 @@ def _process_jobs(
 
     with multiprocessing.Manager() as manager:
         running_jobs: DictProxy[typing.Any, typing.Any] = manager.dict()
-        is_running: ValueProxy = manager.Value("b", True)
+        is_running: ValueProxy[bool] = manager.Value("b", True)
 
         terminal_writer_process = multiprocessing.Process(
             target=_progress_updater, args=(phase, running_jobs, is_running)

--- a/runem/types.py
+++ b/runem/types.py
@@ -146,11 +146,11 @@ class GlobalConfig(typing.TypedDict):
     # Options control the extra flags that are optionally consumed by job.
     # Options configured here are used to set command-line-options. All options
     # and their current state are passed to each job.
-    options: typing.List[OptionConfigSerialised]
+    options: typing.Optional[typing.List[OptionConfigSerialised]]
 
     # File filters control which files will be passed to jobs for a given tags.
     # Job will receive the super-set of files for all that job's tags.
-    files: typing.List[TagFileFilterSerialised]
+    files: typing.Optional[typing.List[TagFileFilterSerialised]]
 
 
 class GlobalSerialisedConfig(typing.TypedDict):

--- a/runem/types.py
+++ b/runem/types.py
@@ -69,7 +69,10 @@ FilePathList = typing.List[FilePathSerialise]
 FilePathListLookup = typing.DefaultDict[JobTag, FilePathList]
 
 # FIXME: this type is no-longer the actual spec of the test-functions
-JobFunction = typing.Callable[[argparse.Namespace, Options, FilePathList], None]
+JobFunction = typing.Union[
+    typing.Callable[[argparse.Namespace, Options, FilePathList], None],
+    typing.Callable[[typing.Any], None],
+]
 
 
 class JobParamConfig(typing.TypedDict):

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -187,7 +187,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
     ]
 
     # use sqlite for unit-tests
-    env_overrides: dict = {
+    env_overrides: typing.Dict[str, str] = {
         "LURSIGHT_DB_SCHEMA": "sqlite",
         "PYTHONPATH": str(root_path / "python"),
     }

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -3,7 +3,7 @@ import shutil
 import typing
 
 from runem.log import log
-from runem.run_command import run_command
+from runem.run_command import RunCommandUnhandledError, run_command
 from runem.types import FilePathList, JobName, JobReturnData, Options
 
 
@@ -123,7 +123,9 @@ def _job_py_mypy(
 ) -> None:
     python_files: FilePathList = kwargs["file_list"]
     mypy_cmd = ["python3", "-m", "mypy", *python_files]
-    run_command(cmd=mypy_cmd, **kwargs)
+    output = run_command(cmd=mypy_cmd, **kwargs)
+    if "mypy.ini" in output or "Not a boolean:" in output:
+        raise RunCommandUnhandledError(f"runem: mypy mis-config detected: {output}")
 
 
 def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-statements

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 """Python setup.py for runem package."""
 import io
 import os
+import typing
 
 from setuptools import find_packages, setup
 
 
-def read(*paths, **kwargs):
+def read(*paths: str, **kwargs: typing.Any) -> str:
     """Read the contents of a text file safely.
 
     >>> read("runem", "VERSION")
@@ -23,7 +24,7 @@ def read(*paths, **kwargs):
     return content
 
 
-def read_requirements(path):
+def read_requirements(path: str) -> typing.List[str]:
     return [
         line.strip()
         for line in read(path).split("\n")

--- a/tests/cli/test_initialise_options.py
+++ b/tests/cli/test_initialise_options.py
@@ -57,7 +57,7 @@ def config_metadata_fixture() -> ConfigMetadata:
     )
 
 
-def test_initialise_options_no_overrides(config_metadata):
+def test_initialise_options_no_overrides(config_metadata: ConfigMetadata) -> None:
     args = Namespace(overrides_on=[], overrides_off=[])
     options = initialise_options(config_metadata, args)
     assert options == {
@@ -68,7 +68,7 @@ def test_initialise_options_no_overrides(config_metadata):
     }
 
 
-def test_initialise_options_overrides_on(config_metadata):
+def test_initialise_options_overrides_on(config_metadata: ConfigMetadata) -> None:
     args = Namespace(overrides_on=["option2", "option4"], overrides_off=[])
     options = initialise_options(config_metadata, args)
     assert options == {
@@ -79,7 +79,7 @@ def test_initialise_options_overrides_on(config_metadata):
     }
 
 
-def test_initialise_options_overrides_off(config_metadata):
+def test_initialise_options_overrides_off(config_metadata: ConfigMetadata) -> None:
     args = Namespace(overrides_on=[], overrides_off=["option1", "option3"])
     options = initialise_options(config_metadata, args)
     assert options == {
@@ -90,7 +90,9 @@ def test_initialise_options_overrides_off(config_metadata):
     }
 
 
-def test_initialise_options_overrides_on_and_off(config_metadata):
+def test_initialise_options_overrides_on_and_off(
+    config_metadata: ConfigMetadata,
+) -> None:
     args = Namespace(overrides_on=["option2"], overrides_off=["option1"])
     options = initialise_options(config_metadata, args)
     assert options == {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ FixtureRequest = typing.Any
 
 # each test runs on cwd to its temp dir
 @pytest.fixture(autouse=True)
-def go_to_tmp_path(request: FixtureRequest) -> typing.Generator:
+def go_to_tmp_path(request: FixtureRequest) -> typing.Generator[None, None, None]:
     # Get the fixture dynamically by its name.
     tmp_path: pathlib.Path = request.getfixturevalue("tmp_path")
     # ensure local test created packages can be imported

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,5 @@
 from runem.base import NAME
 
 
-def test_base():
+def test_base() -> None:
     assert NAME == "runem"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,25 +1,19 @@
 import os
 import pathlib
 
-import yaml
-
 from runem.config import load_config
-from runem.types import Config, GlobalSerialisedConfig
+from runem.types import Config
 
 
 def test_load_config(tmp_path: pathlib.Path) -> None:
-    global_config: GlobalSerialisedConfig = {
-        "config": {
-            "phases": ("mock phase",),
-            "files": [],
-            "options": [],
-        }
-    }
-    empty_config: Config = [
-        global_config,
-    ]
     config_gen_path: pathlib.Path = tmp_path / ".runem.yml"
-    config_gen_path.write_text(yaml.dump_all(empty_config))
+    config_gen_path.write_text(
+        "- config:\n"
+        "    phases:\n"
+        "      - mock phase\n"
+        "    files:\n"
+        "    options:\n"
+    )
 
     # set the working dir to where the config is
     os.chdir(tmp_path)
@@ -27,7 +21,94 @@ def test_load_config(tmp_path: pathlib.Path) -> None:
     loaded_config: Config
     config_read_path: pathlib.Path
     loaded_config, config_read_path = load_config()
-    assert loaded_config == {
-        "config": {"files": [], "options": [], "phases": ("mock phase",)}
-    }
+    expected_config: Config = [
+        {
+            "config": {
+                "files": None,
+                "options": None,
+                "phases": ("mock phase",),
+            }
+        }
+    ]
+    assert loaded_config == expected_config
+    assert config_read_path == config_gen_path
+
+
+def test_load_config_with_no_phases(tmp_path: pathlib.Path) -> None:
+    config_gen_path: pathlib.Path = tmp_path / ".runem.yml"
+    config_gen_path.write_text(
+        (
+            "- config:\n"  # ln 1
+            "    files:\n"  # ln 2
+            "    options:\n"  # ln 3
+        )
+    )
+
+    # set the working dir to where the config is
+    os.chdir(tmp_path)
+
+    loaded_config: Config
+    config_read_path: pathlib.Path
+    loaded_config, config_read_path = load_config()
+    expected_config: Config = [
+        {
+            "config": {  # type: ignore # intentionally testing for missing 'phases'
+                "files": None,
+                "options": None,
+            }
+        }
+    ]
+    assert loaded_config == expected_config
+    assert config_read_path == config_gen_path
+
+
+def test_load_config_with_global_last(tmp_path: pathlib.Path) -> None:
+    config_gen_path: pathlib.Path = tmp_path / ".runem.yml"
+    config_gen_path.write_text(
+        (
+            "- job:\n"  # some job
+            "    addr:\n"
+            "      file: scripts/test_hooks/py.py\n"
+            "      function: _job_py_pytest\n"
+            "    label: pytest\n"
+            "    when:\n"
+            "      phase: analysis\n"
+            "      tags:\n"
+            "        - py\n"
+            "        - unit test\n"
+            "        - test\n"
+            "- config:\n"  # the global config last
+            "    files:\n"
+            "    options:\n"
+        )
+    )
+
+    # set the working dir to where the config is
+    os.chdir(tmp_path)
+
+    loaded_config: Config
+    config_read_path: pathlib.Path
+    loaded_config, config_read_path = load_config()
+    expected_config: Config = [
+        {
+            "job": {
+                "addr": {
+                    "file": "scripts/test_hooks/py.py",
+                    "function": "_job_py_pytest",
+                },
+                "label": "pytest",
+                "when": {
+                    "phase": "analysis",
+                    "tags": ["py", "unit test", "test"],  # type: ignore
+                },
+            }
+        },
+        {
+            "config": {  # type: ignore # intentionally testing for missing 'phases'
+                "files": None,
+                "options": None,
+            }
+        },
+    ]
+    assert loaded_config == expected_config
     assert config_read_path == config_gen_path

--- a/tests/test_config_parse.py
+++ b/tests/test_config_parse.py
@@ -1,5 +1,6 @@
 import io
 import pathlib
+import unittest
 from collections import defaultdict
 from contextlib import redirect_stdout
 from unittest.mock import patch
@@ -129,7 +130,7 @@ def test_parse_global_config_missing() -> None:
 
 def test_parse_global_config_full() -> None:
     """Test the global config parse handles missing data."""
-    dummy_global_config: GlobalConfig = {  # type: ignore
+    dummy_global_config: GlobalConfig = {
         "phases": tuple(),
         "options": [
             {
@@ -334,7 +335,9 @@ def test_parse_config_missing_phases_raises() -> None:
     "runem.config_parse._parse_global_config",
     return_value=(None, (), {}),
 )
-def test_parse_config_warning_if_missing_phase_order(mock_parse_global_config) -> None:
+def test_parse_config_warning_if_missing_phase_order(
+    mock_parse_global_config: unittest.mock.Mock,
+) -> None:
     """Test the global config raises if the phases are missing."""
     dummy_global_config: GlobalSerialisedConfig = {
         "config": {  # type: ignore

--- a/tests/test_job_execute.py
+++ b/tests/test_job_execute.py
@@ -1,4 +1,5 @@
 import pathlib
+import typing
 from argparse import Namespace
 from collections import defaultdict
 
@@ -13,11 +14,13 @@ from runem.types import (
 )
 
 
-def empty_function(**kwargs) -> None:
+def empty_function(**kwargs: typing.Any) -> None:
     """Does nothing, called by runner."""
 
 
-def old_style_function(args: Namespace, options: Options, file_list: FilePathList):
+def old_style_function(
+    args: Namespace, options: Options, file_list: FilePathList
+) -> None:
     """Does nothing called by runner."""
 
 

--- a/tests/test_job_wrapper_python.py
+++ b/tests/test_job_wrapper_python.py
@@ -154,7 +154,7 @@ def test_load_python_function_from_module_handles_module_from_spec_failing(
     mock_module_from_spec.assert_called()
 
 
-def test_load_python_function_success(tmp_path):
+def test_load_python_function_success(tmp_path: pathlib.Path) -> None:
     # Create a temporary Python module file
     p = tmp_path / "hello.py"
     p.write_text('def hello():\n    return "Hello, World!"')
@@ -166,10 +166,10 @@ def test_load_python_function_success(tmp_path):
 
     # True if the function can be called and returns expected result
     assert callable(hello_func)
-    assert hello_func() == "Hello, World!"
+    assert hello_func() == "Hello, World!"  # type: ignore
 
 
-def test_load_python_function_module_not_found(tmp_path):
+def test_load_python_function_module_not_found(tmp_path: pathlib.Path) -> None:
     # Use the function to load a non-existing module
     with pytest.raises(FunctionNotFound):
         _load_python_function_from_module(
@@ -177,7 +177,7 @@ def test_load_python_function_module_not_found(tmp_path):
         )
 
 
-def test_load_python_function_not_found(tmp_path):
+def test_load_python_function_not_found(tmp_path: pathlib.Path) -> None:
     # Create a temporary Python module file
     p = tmp_path / "hello.py"
     p.write_text(
@@ -194,7 +194,7 @@ def test_load_python_function_not_found(tmp_path):
         )
 
 
-def test_load_python_function_invalid_module(tmp_path):
+def test_load_python_function_invalid_module(tmp_path: pathlib.Path) -> None:
     # Create an invalid Python module file
     p = tmp_path / "invalid.py"
     p.write_text(

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -824,7 +824,7 @@ class SleepCalledError(ValueError):
 def create_mock_print_sleep() -> typing.Generator[typing.Tuple[Mock, Mock], None, None]:
     call_count = 0
 
-    def custom_side_effect(*args, **kwargs):
+    def custom_side_effect(*args: typing.Any, **kwargs: typing.Any) -> float:
         nonlocal call_count
         if call_count < 1:
             call_count += 1


### PR DESCRIPTION
### Summary :memo:
We weren't properly running mypy or at least running it as we thought we were. This fixes that root-cause issue and all subsequently detected typing issues.


### Details
The root cause was that we had a comment after the option in mypy to enable 'strict' mode and that was disabling checks. We could only visually see this issue if/when we did get a mypy issue shown.

To fix this:
1. we fix the config so comments don't appear last on the line
2. we add a check to see if there's log output that looks like this issue
3. we fix all typing issues
4. we modify our config loading code as there was a discrepancy there that needed to be addressed, that was only visible when mypy was working *as epected*

This was needed because mypy does not catch mis configurations like this. See https://github.com/python/mypy/issues/16764

### Checks
- [x] Tested Changes
- [x] Stakeholder Approval
