### PR TITLE
Feat/in progress job count

### DIFF
--- a/runem/job_wrapper_python.py
+++ b/runem/job_wrapper_python.py
@@ -26,7 +26,7 @@ def _load_python_function_from_module(
         )
         if not module_spec:
             raise FileNotFoundError()
-        if not module_spec.loader:
+        if not module_spec.loader:  # pragma: FIXME: add code coverage
             raise FunctionNotFound("unable to load module")
     except FileNotFoundError as err:
         raise FunctionNotFound(

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -28,7 +28,7 @@ import typing
 from collections import defaultdict
 from datetime import timedelta
 from itertools import repeat
-from multiprocessing.managers import DictProxy, ValueProxy
+from multiprocessing.managers import DictProxy, ListProxy, ValueProxy
 from timeit import default_timer as timer
 
 from halo import Halo
@@ -54,6 +54,7 @@ from runem.types import (
     PhaseGroupedJobs,
     PhaseName,
 )
+from runem.utils import printable_set
 
 
 def _determine_run_parameters(argv: typing.List[str]) -> ConfigMetadata:
@@ -79,19 +80,47 @@ def _determine_run_parameters(argv: typing.List[str]) -> ConfigMetadata:
     return config_metadata
 
 
-def _progress_updater(
-    label: str, running_jobs: typing.Dict[str, str], is_running: ValueProxy[bool]
+# cSpell:disable # FIXME
+
+
+def _update_progress(
+    label: str,
+    running_jobs: typing.Dict[str, str],
+    seen_jobs: typing.List[str],
+    all_jobs: Jobs,
+    is_running: ValueProxy[bool],
+    num_workers: int,
 ) -> None:
     spinner = Halo(text="", spinner="dots")
     spinner.start()
 
+    all_job_names: typing.Set[str] = {job["label"] for job in all_jobs}
+    last_running_jobs_set: typing.Set[str] = set()
+    completed_jobs: typing.Set[str] = set()
     while is_running.value:
-        running_job_names: typing.List[str] = [
-            f"'{job}'" for job in sorted(list(running_jobs.values()))
-        ]
-        printable_jobs: str = ", ".join(running_job_names)
-        spinner.text = f"{label}: {printable_jobs}"
+        running_jobs_set: typing.Set[str] = set(running_jobs.values())
+        seen_jobs = list(running_jobs_set.union(seen_jobs))
+        disappeared_jobs: typing.Set[str] = last_running_jobs_set - running_jobs_set
+        remaining_jobs: typing.Set[str] = all_job_names - completed_jobs
+
+        # retiring means that there is (no longer?) enough jobs for each worker
+        workers_retiring: bool = len(remaining_jobs) <= num_workers
+        if workers_retiring:
+            # as there isn't enough work for each worker we KNOW that any jobs
+            # that haven't been seen have completed.
+            # This works around the fact that a task may have disappeared whilst
+            # we were sleeping in this process.
+            all_completed_jobs: typing.Set[str] = all_job_names - remaining_jobs
+            disappeared_jobs.update(all_completed_jobs - running_jobs_set)
+        completed_jobs.update(disappeared_jobs)
+        progress: str = f"{len(completed_jobs)}/{len(all_jobs)}"
+        message: str = (
+            f"{label}: {progress}({num_workers}): {printable_set(running_jobs_set)}"
+        )
+        spinner.text = message
+        last_running_jobs_set = set(running_jobs_set)
         time.sleep(0.1)
+
     spinner.stop()
 
 
@@ -125,11 +154,20 @@ def _process_jobs(
     )
 
     with multiprocessing.Manager() as manager:
+        seen_jobs: ListProxy[str] = manager.list()
         running_jobs: DictProxy[typing.Any, typing.Any] = manager.dict()
         is_running: ValueProxy[bool] = manager.Value("b", True)
 
         terminal_writer_process = multiprocessing.Process(
-            target=_progress_updater, args=(phase, running_jobs, is_running)
+            target=_update_progress,
+            args=(
+                phase,
+                running_jobs,
+                seen_jobs,
+                jobs,
+                is_running,
+                num_concurrent_procs,
+            ),
         )
         terminal_writer_process.start()
 

--- a/tests/test_config_parse.py
+++ b/tests/test_config_parse.py
@@ -102,6 +102,40 @@ def test_parse_job_config_throws_on_dupe_name() -> None:
         )
 
 
+def test_parse_job_config_throws_on_missing_key() -> None:
+    """Tests for expected keys are reported if missing."""
+    job_config: JobConfig = {
+        "addr": {
+            "file": __file__,
+            "function": "test_parse_job_config",
+        },
+        # intentionally removed:
+        # "label": "reformat py",
+        "when": {
+            "phase": "edit",
+            "tags": set(
+                (
+                    "py",
+                    "format",
+                )
+            ),
+        },
+    }
+    tags: JobTags = set(["py"])
+    jobs_by_phase: PhaseGroupedJobs = defaultdict(list)
+    job_names: JobNames = set(("reformat py",))
+    phases: JobPhases = set()
+    with pytest.raises(ValueError):
+        parse_job_config(
+            cfg_filepath=pathlib.Path(__file__),
+            job=job_config,
+            in_out_tags=tags,
+            in_out_jobs_by_phase=jobs_by_phase,
+            in_out_job_names=job_names,
+            in_out_phases=phases,
+        )
+
+
 def test_parse_global_config_empty() -> None:
     """Test the global config parse handles empty data."""
     dummy_global_config: GlobalConfig = {


### PR DESCRIPTION
### Summary :memo:
Shows a running progress of how many jobs have been completed.

### Details
We use multiprocess's manager types to communicate between processes to show what work has completed and what has not, showing a running total in the halo progress ticker.

It makes 'runem' "feel nice" to use, especially when you have long-running tasks, and therefore gives a good, intuitive first pass understanding of how well the progress is.