### PR TITLE
Feat/multiple cwd

### DIFF
--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -79,6 +79,8 @@ def parse_job_config(
         # try and load the function _before_ we schedule it's execution
         get_job_wrapper(job, cfg_filepath)
         phase_id: PhaseName = job["when"]["phase"]
+
+        # add the job to the list of jobs
         in_out_jobs_by_phase[phase_id].append(job)
 
         in_out_job_names.add(job["label"])

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -1,7 +1,9 @@
+import copy
 import pathlib
 import sys
 import typing
 from collections import defaultdict
+from collections.abc import Iterable
 
 from runem.config_metadata import ConfigMetadata
 from runem.job_wrapper_python import get_job_wrapper
@@ -57,6 +59,34 @@ def _parse_global_config(
     return phases, options, file_filters
 
 
+def _parse_job(
+    cfg_filepath: pathlib.Path,
+    job: JobConfig,
+    in_out_tags: JobTags,
+    in_out_jobs_by_phase: PhaseGroupedJobs,
+    in_out_job_names: JobNames,
+    in_out_phases: JobPhases,
+) -> None:
+    """Parse an individual job."""
+    job_name_used = job["label"] in in_out_job_names
+    if job_name_used:
+        log("ERROR: duplicate job label!")
+        log(f"\t'{job['label']}' is used twice or more in {str(cfg_filepath)}")
+        sys.exit(1)
+
+        # try and load the function _before_ we schedule it's execution
+    get_job_wrapper(job, cfg_filepath)
+    phase_id: PhaseName = job["when"]["phase"]
+
+    # add the job to the list of jobs
+    in_out_jobs_by_phase[phase_id].append(job)
+
+    in_out_job_names.add(job["label"])
+    in_out_phases.add(job["when"]["phase"])
+    for tag in job["when"]["tags"]:
+        in_out_tags.add(tag)
+
+
 def parse_job_config(
     cfg_filepath: pathlib.Path,
     job: JobConfig,
@@ -70,23 +100,49 @@ def parse_job_config(
     Returns the tags generated
     """
     try:
-        job_name_used = job["label"] in in_out_job_names
-        if job_name_used:
-            log("ERROR: duplicate job label!")
-            log(f"\t'{job['label']}' is used twice or more in {str(cfg_filepath)}")
-            sys.exit(1)
+        # if there is more than one cwd, duplicate the job for each cwd
+        generated_jobs: typing.List[JobConfig] = []
+        have_ctw_cwd: bool = (("ctx" in job) and (job["ctx"] is not None)) and (
+            ("cwd" in job["ctx"]) and (job["ctx"]["cwd"] is not None)
+        )
+        if (not have_ctw_cwd) or isinstance(
+            job["ctx"]["cwd"], str  # type: ignore # handled above
+        ):
+            # if
+            # - we don't have a cwd, ctx
+            # - or if the cwd is just a string, it's a path, just use it
+            generated_jobs.append(job)
+        else:
+            assert job["ctx"] is not None
+            assert job["ctx"]["cwd"] is not None
+            assert isinstance(job["ctx"]["cwd"], Iterable)
+            assert isinstance(job["ctx"]["cwd"], list)
+            cwd_list: typing.List[str] = job["ctx"]["cwd"]
+            cwd: str
+            for cwd in cwd_list:
+                specialised_job_for_cwd = copy.deepcopy(job)
+                # overwrite the list of cwd paths with just the single instance
+                assert (
+                    "ctx" in specialised_job_for_cwd and specialised_job_for_cwd["ctx"]
+                ), specialised_job_for_cwd
+                assert (
+                    "cwd" in specialised_job_for_cwd["ctx"]
+                    and specialised_job_for_cwd["ctx"]["cwd"]
+                ), specialised_job_for_cwd["ctx"].keys()
+                specialised_job_for_cwd["ctx"]["cwd"] = cwd
+                # update the label to reflect the specialisation
+                specialised_job_for_cwd["label"] = f"{job['label']}({cwd})"
+                generated_jobs.append(specialised_job_for_cwd)
 
-        # try and load the function _before_ we schedule it's execution
-        get_job_wrapper(job, cfg_filepath)
-        phase_id: PhaseName = job["when"]["phase"]
-
-        # add the job to the list of jobs
-        in_out_jobs_by_phase[phase_id].append(job)
-
-        in_out_job_names.add(job["label"])
-        in_out_phases.add(job["when"]["phase"])
-        for tag in job["when"]["tags"]:
-            in_out_tags.add(tag)
+        for generated_job in generated_jobs:
+            _parse_job(
+                cfg_filepath,
+                generated_job,
+                in_out_tags,
+                in_out_jobs_by_phase,
+                in_out_job_names,
+                in_out_phases,
+            )
     except KeyError as err:
         raise ValueError(
             f"job config entry is missing '{err.args[0]}' data. Have {job}"

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -70,8 +70,8 @@ def parse_job_config(
     Returns the tags generated
     """
     try:
-        job_names_used = job["label"] in in_out_job_names
-        if job_names_used:
+        job_name_used = job["label"] in in_out_job_names
+        if job_name_used:
             log("ERROR: duplicate job label!")
             log(f"\t'{job['label']}' is used twice or more in {str(cfg_filepath)}")
             sys.exit(1)

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -67,8 +67,6 @@ def parse_job_config(
 ) -> None:
     """Parses and validates a job-entry read in from disk.
 
-    Tries to relocate the function address relative to the config-file
-
     Returns the tags generated
     """
     try:

--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -54,6 +54,7 @@ def job_execute_inner(
         and "cwd" in job_config["ctx"]
         and job_config["ctx"]["cwd"]
     ):
+        assert isinstance(job_config["ctx"]["cwd"], str)
         os.chdir(root_path / job_config["ctx"]["cwd"])
     else:
         os.chdir(root_path)

--- a/runem/job_filter.py
+++ b/runem/job_filter.py
@@ -106,6 +106,7 @@ def filter_jobs(
             continue
 
         log((f"will run {len(filtered_jobs[phase])} jobs for phase '{phase}'"))
-        log(f"\t{[job['label'] for job in filtered_jobs[phase]]}")
+        job_names: JobNames = set([job["label"] for job in filtered_jobs[phase]])
+        log(f"\t{printable_set(job_names)}")
 
     return filtered_jobs

--- a/runem/job_filter.py
+++ b/runem/job_filter.py
@@ -106,7 +106,7 @@ def filter_jobs(
             continue
 
         log((f"will run {len(filtered_jobs[phase])} jobs for phase '{phase}'"))
-        job_names: JobNames = set([job["label"] for job in filtered_jobs[phase]])
+        job_names: JobNames = {job["label"] for job in filtered_jobs[phase]}
         log(f"\t{printable_set(job_names)}")
 
     return filtered_jobs

--- a/runem/types.py
+++ b/runem/types.py
@@ -92,8 +92,12 @@ class JobAddressConfig(typing.TypedDict):
 
 
 class JobContextConfig(typing.TypedDict, total=False):
-    params: typing.Optional[JobParamConfig]  # what parameters the job needs
-    cwd: typing.Optional[str]  # the path to run the command in
+    # what parameters the job needs # DEFUNCT
+    params: typing.Optional[JobParamConfig]
+
+    # the path or paths to run the command in. If given a list the job will be
+    # duplicated for each given path.
+    cwd: typing.Optional[typing.Union[str, typing.List[str]]]
 
 
 class JobWhen(typing.TypedDict):

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -265,9 +265,9 @@ def test_runem_with_full_config() -> None:
             "'tag only on job 1', 'tag only on job 2'"
         ),
         "runem: will run 1 jobs for phase 'dummy phase 1'",
-        "runem: \t['dummy job label 1']",
+        "runem: \t'dummy job label 1'",
         "runem: will run 1 jobs for phase 'dummy phase 2'",
-        "runem: \t['dummy job label 2']",
+        "runem: \t'dummy job label 2'",
         # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
         # "runem: Running 'dummy phase 2' with 1 workers processing 1 jobs",
     ] == runem_stdout
@@ -297,9 +297,9 @@ def test_runem_with_full_config_verbose() -> None:
             "'tag only on job 1', 'tag only on job 2'"
         ),
         "runem: will run 1 jobs for phase 'dummy phase 1'",
-        "runem: \t['dummy job label 1']",
+        "runem: \t'dummy job label 1'",
         "runem: will run 1 jobs for phase 'dummy phase 2'",
-        "runem: \t['dummy job label 2']",
+        "runem: \t'dummy job label 2'",
         "runem: Running Phase dummy phase 1",
         # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
         "runem: Running Phase dummy phase 2",
@@ -329,7 +329,7 @@ def test_runem_with_single_phase() -> None:
             "'tag only on job 1', 'tag only on job 2'"
         ),
         "runem: will run 1 jobs for phase 'dummy phase 1'",
-        "runem: \t['dummy job label 1']",
+        "runem: \t'dummy job label 1'",
         "runem: skipping phase 'dummy phase 2'",
         # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
     ] == runem_stdout
@@ -358,7 +358,7 @@ def test_runem_with_single_phase_verbose() -> None:
             "'tag only on job 1', 'tag only on job 2'"
         ),
         "runem: will run 1 jobs for phase 'dummy phase 1'",
-        "runem: \t['dummy job label 1']",
+        "runem: \t'dummy job label 1'",
         "runem: skipping phase 'dummy phase 2'",
         "runem: Running Phase dummy phase 1",
         # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
@@ -561,7 +561,7 @@ def test_runem_job_filters_work(verbosity: bool) -> None:
                 "'tag only on job 1', 'tag only on job 2'"
             ),
             "runem: will run 1 jobs for phase 'dummy phase 1'",
-            "runem: \t['dummy job label 1']",
+            "runem: \t'dummy job label 1'",
             (
                 "runem: not running job 'dummy job label 2' because it isn't in the list "
                 "of job names. See --jobs and --not-jobs"
@@ -582,7 +582,7 @@ def test_runem_job_filters_work(verbosity: bool) -> None:
                 "'tag only on job 1', 'tag only on job 2'"
             ),
             "runem: will run 1 jobs for phase 'dummy phase 1'",
-            "runem: \t['dummy job label 1']",
+            "runem: \t'dummy job label 1'",
             (
                 "runem: No jobs for phase 'dummy phase 2' tags 'dummy tag 1', "
                 "'dummy tag 2', 'tag only on job 1', "
@@ -625,7 +625,7 @@ def test_runem_tag_filters_work(verbosity: bool) -> None:
             "runem: found 1 batches, 1 'mock phase' files, ",
             "runem: filtering for tags 'tag only on job 1'",
             "runem: will run 1 jobs for phase 'dummy phase 1'",
-            "runem: \t['dummy job label 1']",
+            "runem: \t'dummy job label 1'",
             (
                 "runem: not running job 'dummy job label 2' because it doesn't have any of the "
                 "following tags: 'tag only on job 1'"
@@ -639,7 +639,7 @@ def test_runem_tag_filters_work(verbosity: bool) -> None:
             "runem: found 1 batches, 1 'mock phase' files, ",
             "runem: filtering for tags 'tag only on job 1'",
             "runem: will run 1 jobs for phase 'dummy phase 1'",
-            "runem: \t['dummy job label 1']",
+            "runem: \t'dummy job label 1'",
             "runem: No jobs for phase 'dummy phase 2' tags 'tag only on job 1'",
             # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
         ]
@@ -689,7 +689,7 @@ def test_runem_tag_out_filters_work(verbosity: bool) -> None:
                 "'tag only on job 2'"
             ),
             "runem: will run 1 jobs for phase 'dummy phase 2'",
-            "runem: \t['dummy job label 2']",
+            "runem: \t'dummy job label 2'",
             "runem: Running Phase dummy phase 2",
             # "runem: Running 'dummy phase 2' with 1 workers processing 1 jobs",
         ]
@@ -705,7 +705,7 @@ def test_runem_tag_out_filters_work(verbosity: bool) -> None:
                 "'tag only on job 2'"
             ),
             "runem: will run 1 jobs for phase 'dummy phase 2'",
-            "runem: \t['dummy job label 2']",
+            "runem: \t'dummy job label 2'",
             # "runem: Running 'dummy phase 2' with 1 workers processing 1 jobs",
         ]
 
@@ -804,7 +804,7 @@ def test_runem_phase_filters_work(verbosity: bool) -> None:
                 "'tag only on job 2'"
             ),
             "runem: will run 1 jobs for phase 'dummy phase 1'",
-            "runem: \t['dummy job label 1']",
+            "runem: \t'dummy job label 1'",
             "runem: skipping phase 'dummy phase 2'",
             "runem: Running Phase dummy phase 1",
             # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
@@ -817,7 +817,7 @@ def test_runem_phase_filters_work(verbosity: bool) -> None:
                 "'tag only on job 2'"
             ),
             "runem: will run 1 jobs for phase 'dummy phase 1'",
-            "runem: \t['dummy job label 1']",
+            "runem: \t'dummy job label 1'",
             "runem: skipping phase 'dummy phase 2'",
             # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
         ]


### PR DESCRIPTION
### Summary :memo:
Allows a job to be duplicated for multiple cwds

### Details

This leverages the multi-proc aspects of runem to get faster results when the same command is run on multiple directories. Normally using bash it is *far* easier to run the checks in serial, but with runem we can run them in parallel, getting a faster completion.

Given the following config, the `_some_check` function will be run with a cwd of `packages/pkg1`, `packages/pkg2`, and ,`packages/pkg3`.

```yml
- job:
    addr:
      file: path_to_file.py
      function: _some_check
    ctx:
      cwd:
        - packages/pkg1
        - packages/pkg2
        - packages/pkg3
    label: my:check
    when:
      phase: some_phase
      tags:
        - tag1
        - tag2
```
