### PR TITLE
Feat/show reports even on failure

### DIFF
--- a/runem/run_command.py
+++ b/runem/run_command.py
@@ -28,7 +28,7 @@ def get_stdout(process: CompletedProcess[bytes], prefix: str) -> str:
         stdout = str(process.stdout.decode("utf-8"))
     except UnboundLocalError:
         stdout = "No process started, does it exist?"
-    stdout = stdout.replace("\n", f"\n{prefix}")
+    stdout = prefix + stdout.replace("\n", f"\n{prefix}")
     return stdout
 
 
@@ -117,7 +117,7 @@ def run_command(  # noqa: C901 # pylint: disable=too-many-branches
             f"runem: test: FATAL: command failed: {label}"
             f"\n\t{env_overrides_as_string}{cmd_string}"
             f"\nERROR"
-            f"\n\t{str(stdout)}"
+            f"\n{str(stdout)}"
             f"\nERROR END"
         )
 
@@ -127,7 +127,7 @@ def run_command(  # noqa: C901 # pylint: disable=too-many-branches
         raise RunCommandUnhandledError(error_string) from err
 
     assert process is not None
-    cmd_stdout: str = get_stdout(process, prefix=label)
+    cmd_stdout: str = get_stdout(process, prefix=f"{label}: ")
     if verbose:
         log(cmd_stdout)
         log(f"running: done: {label}: {cmd_string}")

--- a/tests/intentional_test_error.py
+++ b/tests/intentional_test_error.py
@@ -1,0 +1,5 @@
+class IntentionalTestError(RuntimeError):
+    pass
+
+    def __init__(self) -> None:
+        super().__init__(self, "expected test error")

--- a/tests/test_job_execute.py
+++ b/tests/test_job_execute.py
@@ -17,10 +17,16 @@ from runem.types import (
     Options,
     PhaseGroupedJobs,
 )
+from tests.intentional_test_error import IntentionalTestError
 
 
 def empty_function(**kwargs: typing.Any) -> None:
     """Does nothing, called by runner."""
+
+
+def intentionally_raising_function(**kwargs: typing.Any) -> None:
+    """Raises an error called by runner."""
+    raise IntentionalTestError()
 
 
 def old_style_function(
@@ -34,13 +40,19 @@ def _job_execute_and_capture_stdout(
     running_jobs: typing.Dict[str, str],
     config_metadata: ConfigMetadata,
     file_lists: FilePathListLookup,
-) -> str:
+) -> typing.Tuple[str, typing.Optional[BaseException]]:
     """Runs job execute and asserts on stdout."""
+    ret_err: typing.Optional[BaseException] = None
     with io.StringIO() as buf, redirect_stdout(buf):
-        job_execute(job_config, running_jobs, config_metadata, file_lists)
+        try:
+            job_execute(job_config, running_jobs, config_metadata, file_lists)
+        except BaseException as err:  # pylint: disable=broad-exception-caught
+            # capture the error and return it
+            ret_err = err
+        # also capture the stdout so we can inspect that as well.
         stdout: str = buf.getvalue()
     # float_less_stdout = re.sub(r"\d+\.\d+", "[FLOAT]", stdout)
-    return stdout
+    return stdout, ret_err
 
 
 @pytest.fixture(name="mock_timer", autouse=True)
@@ -103,7 +115,7 @@ def test_job_execute_basic_call() -> None:
 
     file_lists: FilePathListLookup = defaultdict(list)
     file_lists["dummy tag"] = [__file__]
-    stdout: str = _job_execute_and_capture_stdout(
+    stdout, _ = _job_execute_and_capture_stdout(
         job_config,
         {},
         config_metadata,
@@ -161,7 +173,7 @@ def test_job_execute_basic_call_verbose() -> None:
 
     file_lists: FilePathListLookup = defaultdict(list)
     file_lists["dummy tag"] = [__file__]
-    stdout: str = _job_execute_and_capture_stdout(
+    stdout, _ = _job_execute_and_capture_stdout(
         job_config,
         {},
         config_metadata,
@@ -223,7 +235,7 @@ def test_job_execute_empty_files() -> None:
 
     file_lists: FilePathListLookup = defaultdict(list)
     # file_lists["dummy tag"] = [__file__]
-    stdout: str = _job_execute_and_capture_stdout(
+    stdout, _ = _job_execute_and_capture_stdout(
         job_config,
         {},
         config_metadata,
@@ -290,7 +302,7 @@ def test_job_execute_with_ctx_cwd() -> None:
 
     file_lists: FilePathListLookup = defaultdict(list)
     file_lists["dummy tag"] = [__file__]
-    stdout: str = _job_execute_and_capture_stdout(
+    stdout, _ = _job_execute_and_capture_stdout(
         job_config,
         {},
         config_metadata,
@@ -356,7 +368,7 @@ def test_job_execute_with_old_style_func() -> None:
 
     file_lists: FilePathListLookup = defaultdict(list)
     file_lists["dummy tag"] = [__file__]
-    stdout: str = _job_execute_and_capture_stdout(
+    stdout, _ = _job_execute_and_capture_stdout(
         job_config,
         {},
         config_metadata,
@@ -366,4 +378,80 @@ def test_job_execute_with_old_style_func() -> None:
         "runem: START: reformat py\n"
         "runem: job: running reformat py\n"
         "runem: DONE: reformat py: 0:00:00\n"
+    )
+
+
+def test_job_execute_with_raising_func() -> None:
+    """Tests that the output is sane on a job-function-raise.
+
+    Aka a job-function throw.
+
+    This test should show that it is the Python exception-handling code that
+    repeats output, not the run'em code.
+
+    FIXME: this contains a lot of copy-pasted code from above.
+    """
+    job_config: JobConfig = {
+        "addr": {
+            "file": __file__,
+            "function": "intentionally_raising_function",
+        },
+        "label": "intentionally throwing",
+        "when": {
+            "phase": "edit",
+            "tags": set(("dummy tag",)),
+        },
+        "ctx": {
+            # set the cwd
+            "cwd": ".",
+        },
+    }
+    config_file_path = pathlib.Path(__file__).parent / ".runem.yml"
+
+    expected_jobs: PhaseGroupedJobs = defaultdict(list)
+    expected_jobs["dummy phase 1"] = [
+        job_config,
+    ]
+    config_metadata: ConfigMetadata = ConfigMetadata(
+        cfg_filepath=config_file_path,
+        phases=("dummy phase 1",),
+        options_config=tuple(),
+        file_filters={
+            # "dummy tag": {
+            #     "tag": "dummy tag",
+            #     "regex": ".*1.txt",  # should match just one file
+            # }
+        },
+        jobs=expected_jobs,
+        all_job_names=set(("dummy job label",)),
+        all_job_phases=set(("dummy phase 1",)),
+        all_job_tags=set(
+            (
+                "dummy tag 2",
+                "dummy tag 1",
+            )
+        ),
+    )
+    config_metadata.set_cli_data(
+        args=Namespace(verbose=True, procs=1),
+        jobs_to_run=set((job_config["label"])),  # JobNames,
+        phases_to_run=set(),  # ignored JobPhases,
+        tags_to_run=set(),  # ignored JobTags,
+        tags_to_avoid=set(),  # ignored  JobTags,
+        options={},  # Options,
+    )
+
+    file_lists: FilePathListLookup = defaultdict(list)
+    file_lists["dummy tag"] = [__file__]
+
+    stdout, err = _job_execute_and_capture_stdout(
+        job_config,
+        {},
+        config_metadata,
+        file_lists,
+    )
+    assert isinstance(err, IntentionalTestError)
+    assert stdout == (
+        "runem: START: intentionally throwing\n"
+        "runem: job: running intentionally throwing\n"
     )

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -22,7 +22,7 @@ def test_get_stdout() -> None:
             self.stdout = str.encode("test string")
 
     dummy_process: subprocess.CompletedProcess[bytes] = DummyProcess()
-    assert "test string" == runem.run_command.get_stdout(dummy_process, "test")
+    assert "test: test string" == runem.run_command.get_stdout(dummy_process, "test: ")
 
 
 def test_get_stdout_handles_non_started_processes() -> None:
@@ -50,8 +50,8 @@ def test_get_stdout_handles_non_started_processes() -> None:
             self.stdout = DummyString()  # type: ignore  # "mocking" bytes string
 
     dummy_process: subprocess.CompletedProcess[bytes] = DummyProcess()
-    assert "No process started, does it exist?" == runem.run_command.get_stdout(
-        dummy_process, "test"
+    assert "test: No process started, does it exist?" == runem.run_command.get_stdout(
+        dummy_process, "test: "
     )
 
 
@@ -72,7 +72,7 @@ def test_run_command_basic_call(run_mock: Mock) -> None:
             cmd=["ls"], label="test command", verbose=False
         )
         run_command_stdout = buf.getvalue()
-    assert output == "test output"
+    assert output == "test command: test output"
     assert "" == run_command_stdout, "expected empty output when verbosity is off"
     run_mock.assert_called_once()
     assert len(run_mock.call_args) == 2
@@ -96,13 +96,13 @@ def test_run_command_basic_call_verbose(run_mock: Mock) -> None:
             cmd=["ls"], label="test command", verbose=True
         )
         run_command_stdout = buf.getvalue()
-    assert output == "test output"
+    assert output == "test command: test output"
 
     # check the log output hasn't changed. Update as needed.
     assert run_command_stdout == (
         "runem: running: start: test command: ls\n"
         "runem: RUN ENV OVERRIDES: LANG_DO_PRINTS='True' ls\n"
-        "runem: test output\n"
+        "runem: test command: test output\n"
         "runem: running: done: test command: ls\n"
     )
     run_mock.assert_called_once()
@@ -209,7 +209,7 @@ def test_run_command_ignore_fails_skips_no_side_effects_on_success(
             ignore_fails=True,
         )
         assert (
-            output == "test output"
+            output == "test command: test output"
         ), "expected empty output on failed run with 'ignore_fails=True'"
 
         run_command_stdout = buf.getvalue()
@@ -241,7 +241,7 @@ def test_run_command_ignore_fails_skips_no_side_effects_on_success_with_valid_ex
             ignore_fails=True,
         )
         assert (
-            output == "test output"
+            output == "test command: test output"
         ), "expected empty output on failed run with 'ignore_fails=True'"
 
         run_command_stdout = buf.getvalue()
@@ -270,7 +270,7 @@ def test_run_command_basic_call_non_standard_exit_ok_code(run_mock: Mock) -> Non
             valid_exit_ids=(3,),  # matches the monkey-patch config about
         )
         run_command_stdout = buf.getvalue()
-    assert output == "test output"
+    assert output == "test command: test output"
 
     # check the log output hasn't changed. Update as needed.
     assert run_command_stdout == ""
@@ -298,14 +298,14 @@ def test_run_command_basic_call_non_standard_exit_ok_code_verbose(
             valid_exit_ids=(3,),  # matches the monkey-patch config about
         )
         run_command_stdout = buf.getvalue()
-    assert output == "test output"
+    assert output == "test command: test output"
 
     # check the log output hasn't changed. Update as needed.
     assert run_command_stdout == (
         "runem: running: start: test command: ls\n"
         "runem: 	allowed return ids are: 3\n"
         "runem: RUN ENV OVERRIDES: LANG_DO_PRINTS='True' ls\n"
-        "runem: test output\n"
+        "runem: test command: test output\n"
         "runem: running: done: test command: ls\n"
     )
     run_mock.assert_called_once()
@@ -328,7 +328,7 @@ def test_run_command_with_env(run_mock: Mock) -> None:
             env_overrides={"TEST_ENV_1": "1", "TEST_ENV_2": "2"},
         )
         run_command_stdout = buf.getvalue()
-    assert output == "test output"
+    assert output == "test command: test output"
     assert "" == run_command_stdout, "expected empty output when verbosity is off"
     assert len(run_mock.call_args) == 2
     assert run_mock.call_args[0] == (["ls"],)
@@ -357,12 +357,12 @@ def test_run_command_with_env_verbose(run_mock: Mock) -> None:
             env_overrides={"TEST_ENV_1": "1", "TEST_ENV_2": "2"},
         )
         run_command_stdout = buf.getvalue()
-    assert output == "test output"
+    assert output == "test command: test output"
     assert run_command_stdout == (
         "runem: running: start: test command: ls\n"
         "runem: RUN ENV OVERRIDES: LANG_DO_PRINTS='True' ls\n"
         "runem: ENV OVERRIDES: TEST_ENV_1='1' TEST_ENV_2='2' ls\n"
-        "runem: test output\n"
+        "runem: test command: test output\n"
         "runem: running: done: test command: ls\n"
     )
     assert len(run_mock.call_args) == 2

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -852,6 +852,7 @@ def test_progress_updater_with_running_jobs(mock_sleep: Mock) -> None:
             all_jobs=[],
             is_running=manager.Value("b", True),
             num_workers=1,
+            show_spinner=False,
         )
     mock_sleep.assert_called()
 
@@ -888,6 +889,7 @@ def test_progress_updater_with_running_jobs_and_10_jobs(mock_sleep: Mock) -> Non
             all_jobs=all_jobs,
             is_running=manager.Value("b", True),
             num_workers=1,
+            show_spinner=False,
         )
     mock_sleep.assert_called()
 
@@ -902,6 +904,7 @@ def test_progress_updater_without_running_jobs(mock_sleep: Mock) -> None:
             all_jobs=[],
             is_running=manager.Value("b", True),
             num_workers=1,
+            show_spinner=False,
         )
     mock_sleep.assert_called()
 
@@ -916,6 +919,7 @@ def test_progress_updater_with_empty_running_jobs(mock_sleep: Mock) -> None:
             all_jobs=[],
             is_running=manager.Value("b", True),
             num_workers=1,
+            show_spinner=False,
         )
     mock_sleep.assert_called()
 
@@ -924,5 +928,33 @@ def test_progress_updater_with_false() -> None:
     running_jobs: typing.Dict[str, str] = {"job1": ""}
     with multiprocessing.Manager() as manager:
         _update_progress(
-            "dummy label", running_jobs, [], [], manager.Value("b", False), 1
+            "dummy label",
+            running_jobs,
+            [],
+            [],
+            manager.Value("b", False),
+            1,
+            show_spinner=False,
         )
+
+
+class IntentionalTestError(RuntimeError):
+    pass
+
+    def __init__(self) -> None:
+        super().__init__(self, "expected test error")
+
+
+@patch(
+    "runem.runem._main",
+    return_value=(
+        (),  # phase_run_oder,
+        (),  # job_run_metadatas,
+        IntentionalTestError(),
+    ),
+)
+def test_runem_re_raises_after_reporting(
+    main_mock: Mock,
+) -> None:
+    with pytest.raises(IntentionalTestError):
+        timed_main([])

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -22,6 +22,7 @@ from runem.types import (
     Jobs,
     JobSerialisedConfig,
 )
+from tests.intentional_test_error import IntentionalTestError
 
 
 def _remove_x_of_y_workers_log(
@@ -936,13 +937,6 @@ def test_progress_updater_with_false() -> None:
             1,
             show_spinner=False,
         )
-
-
-class IntentionalTestError(RuntimeError):
-    pass
-
-    def __init__(self) -> None:
-        super().__init__(self, "expected test error")
 
 
 @patch(


### PR DESCRIPTION
### Summary :memo:
If an error occurs in any of the sub jobs, you do not get meta-data or reporting for the successful jobs.

### Details
Sometimes you add work which causes a failure in one place and a performance decrease in another, and detecting both can be useful, especially if the performance decrease is in an earlier test-phase.