### PR TITLE
chore(tidy): removes lursight specific env variables

### DIFF
--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -187,10 +187,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
     ]
 
     # use sqlite for unit-tests
-    env_overrides: typing.Dict[str, str] = {
-        "LURSIGHT_DB_SCHEMA": "sqlite",
-        "PYTHONPATH": str(root_path / "python"),
-    }
+    env_overrides: typing.Dict[str, str] = {}
 
     kwargs["label"] = f"{label} pytest"
     run_command(


### PR DESCRIPTION
### Summary :memo:

Removes some env variables that shouldn't have been kept when we split the code from lursight private code.
