### PR TITLE
Feat: Adds a faster way to add basic tasks to `.runem.yml` configs

### DIFF
--- a/.runem.yml
+++ b/.runem.yml
@@ -142,10 +142,7 @@
       tags:
         - json
 - job:
-    addr:
-      file: scripts/test_hooks/yarn.py
-      function: _job_spellcheck
-    label: spell check
+    command: yarn run spellCheck
     when:
       phase: analysis
       tags:
@@ -160,3 +157,5 @@
       tags:
         - json
         - format
+- job:
+    command: ls -alh runem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
+    "python.testing.pytestArgs": ["tests"],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true
 }

--- a/README.md
+++ b/README.md
@@ -1,70 +1,94 @@
-# Run 'em: Run your developer-local tasks faster
+# Run 'em
+
+## Reducing the wall-clock time running your developer-local tasks
+
+`runem` (run 'em) is an unopinionated way to declare and run the many command-line tools developers use regularly.
 
 ## 1. Overview
 
-`runem` (run 'em) is a declarative tools designed to optimise the running of developer jobs concurrently.
+The core objective of Run'em's (pronounced 'run them') is to minimize the wall-clock time required for executing whatever command-line tools a developer uses (or *should* use). Overall it is designed to enhance iteration speed and boost developer productivity.
 
-`runem` is designed to be simple to use and easy to learn, but powerful to use.
+`runem` is also designed to be easy to learn and simple to use, but `runem` also has many powerful tools for advanced users.
 
-Job definitions are declarative and simple and the reports show how long each job took, and how much time `runem` saved you.
+Job definitions are declarative and simple.
 
-The name "runem" is derived from the fusion of "run" and "them," encapsulating the essence of executing tasks quickly.
+The in-built reports show how long each job took and how much time `runem` saved you.
 
-- [Run 'em: Run your developer-local tasks faster](#run-em-run-your-developer-local-tasks-faster)
+Jobs can be filtered in or out very easily.
+
+Multiple projects can be supported in a single `.runem.yml` config, support workspaces and mono-repos. Also multiple task types, working on multiple file-types can be supported.
+
+Finally, because of how it's built, job definitions are auto-documented via `runem --help`. This help onboarding new developers by making tool-discovery easier. Therefore it also helps maintenance of developer tools.
+
+### 1.1. Why is it called `runem`?
+
+Primarily `runem`, as a command line tool, is quick to type and tries to just get out of the way when running your developer-local tools.
+
+The name "runem" is derived from the fusion of "run" and "them," encapsulating the essence of doing the same things, but slightly faster.
+
+## 2. Contents
+- [Run 'em](#run-em)
+  - [Reducing the wall-clock time running your developer-local tasks](#reducing-the-wall-clock-time-running-your-developer-local-tasks)
   - [1. Overview](#1-overview)
-  - [2. Features](#2-features)
-  - [3. Installation](#3-installation)
-  - [4 Quick start](#4-quick-start)
-  - [4.1 A more complete Quick start](#41-a-more-complete-quick-start)
-  - [5. Basic Usage](#5-basic-usage)
-    - [5.1. Tag filters](#51-tag-filters)
-      - [5.1.1. Run jobs only with the 'lint' tag:](#511-run-jobs-only-with-the-lint-tag)
-      - [5.1.2. If you want to lint all code _except_ nodejs code (and you have the appropriate tags):](#512-if-you-want-to-lint-all-code-except-nodejs-code-and-you-have-the-appropriate-tags)
-      - [5.1.3. Run fast checks on `pre-commit`](#513-run-fast-checks-on-pre-commit)
-    - [5.2. phase filters](#52-phase-filters)
-      - [5.2.1 Focus on a phase](#521-focus-on-a-phase)
-      - [5.2.2 Exclude slow phases temporarily](#522-exclude-slow-phases-temporarily)
-  - [6 Reports on your tasks](#6-reports-on-your-tasks)
-    - [6.1 Task timings report](#61-task-timings-report)
-    - [6.2 Bar-graphs with \`termplotlib\`\`](#62-bar-graphs-with-termplotlib)
-  - [7. Using Help to get an Overview of Your Jobs](#7-using-help-to-get-an-overview-of-your-jobs)
-  - [8. Configuration](#8-configuration)
-    - [8.1. `config` - Run 'em global config](#81-config---run-em-global-config)
-    - [8.2. `job` - Job config](#82-job---job-config)
-  - [9. Troubleshooting \& Known issues](#9-troubleshooting--known-issues)
-    - [9.1 I don't see bar graph timing reports!](#91-i-dont-see-bar-graph-timing-reports)
+    - [1.1. Why is it called `runem`?](#11-why-is-it-called-runem)
+  - [2. Contents](#2-contents)
+  - [3. Feature overview](#3-feature-overview)
+  - [4. Installation](#4-installation)
+  - [5. Quick-start](#5-quick-start)
+  - [5.1. Basic quick-start](#51-basic-quick-start)
+    - [5.2. A more complete quick-start](#52-a-more-complete-quick-start)
+      - [5.2.1. A simple `.runem.yml`](#521-a-simple-runemyml)
+      - [5.2.2. A simple python task](#522-a-simple-python-task)
+  - [6. Basic usage](#6-basic-usage)
+    - [6.1. Tag filters](#61-tag-filters)
+      - [6.1.1. Run jobs only with the 'lint' tag:](#611-run-jobs-only-with-the-lint-tag)
+      - [6.1.2. If you want to lint all code _except_ nodejs code (and you have the appropriate tags):](#612-if-you-want-to-lint-all-code-except-nodejs-code-and-you-have-the-appropriate-tags)
+      - [6.1.3. Run fast checks on `pre-commit`](#613-run-fast-checks-on-pre-commit)
+    - [6.2. Phase filters](#62-phase-filters)
+      - [6.2.1. Focus on a phase](#621-focus-on-a-phase)
+      - [6.2.2. Exclude slow phases temporarily](#622-exclude-slow-phases-temporarily)
+  - [7. Reports on your tasks](#7-reports-on-your-tasks)
+    - [7.1. Task timings report](#71-task-timings-report)
+    - [7.2. Bar-graphs with `termplotlib`](#72-bar-graphs-with-termplotlib)
+  - [8. Using \`--help\`\` to get an overview of your Jobs](#8-using---help-to-get-an-overview-of-your-jobs)
+  - [9. Configuration](#9-configuration)
+    - [9.1. `config` - Run 'em global config](#91-config---run-em-global-config)
+    - [9.2. `job` - Job config](#92-job---job-config)
+  - [10. Troubleshooting \& Known issues](#10-troubleshooting--known-issues)
+    - [9.1. I don't see bar graph timing reports!](#91-i-dont-see-bar-graph-timing-reports)
       - [Solution:](#solution)
-    - [9.2 I can't specify a dependency!](#92-i-cant-specify-a-dependency)
+    - [10.2. I can't specify a dependency!](#102-i-cant-specify-a-dependency)
       - [Solution](#solution-1)
-    - [9.3 Why is there so much output on errors, it looks duplicated?](#93-why-is-there-so-much-output-on-errors-it-looks-duplicated)
+    - [10.3. Why is there so much output on errors, it looks duplicated?](#103-why-is-there-so-much-output-on-errors-it-looks-duplicated)
       - [Solution](#solution-2)
-    - [9.4 I can't see reports for job when errors happen!](#94-i-cant-see-reports-for-job-when-errors-happen)
+    - [10.4. When errors happen I don't see reports for jobs!](#104-when-errors-happen-i-dont-see-reports-for-jobs)
       - [Solution](#solution-3)
-    - [9.5 I want to see log output for tasks in real-time, as they're happening!](#95-i-want-to-see-log-output-for-tasks-in-real-time-as-theyre-happening)
+    - [10.5. I want to see log output for tasks in real-time, as they're happening!](#105-i-want-to-see-log-output-for-tasks-in-real-time-as-theyre-happening)
       - [Solution](#solution-4)
 - [Contributing to and supporting runem](#contributing-to-and-supporting-runem)
   - [Development](#development)
   - [Sponsor](#sponsor)
 
 
-## 2. Features
+## 3. Feature overview
 
 - **Declarative Tasks** Describe all your tasks once, and optionally describe how and when to run them.
 
 - **Tagged Jobs:** Use tagging to define which type of jobs you want to run, be it `pre-commit`, `lint`, `test` or in multi-project codebases to split between running `python`, `node.js` or `c++` jobs, depending on the context you are working in!
 
 - **Multiprocess Execution:** Leverage the power of multiprocessing for concurrent test job execution, optimizing efficiency and reducing runtime.
-  
+
 - **Data-Driven Test Management:** Drive your tests with data, making it easy to adapt and scale your testing suite to various scenarios, allowing you to execute, track, and analyze your dev-ops suite with ease.
 
-## 3. Installation
+## 4. Installation
 
 ```bash
 pip install runem
 ```
 
-## 4 Quick start
+## 5. Quick-start
 
+## 5.1. Basic quick-start
 Create the following `.runem.yml` file at the root of your project:
 
 ```yml
@@ -72,39 +96,27 @@ Create the following `.runem.yml` file at the root of your project:
     command: echo "hello world!"
 ```
 
-Then anywhere in your project run, to see how and when that task is run, and how long it took.
-```sh
+Then anywhere in your project run `runem` to see how and when that task is run, and how long it took:
+```bash
 runem
+```
 
+To see the actual log output you will need to use `--verbose` as `runem` hides anything that isn't important. Only failures and reports are considered important.
+```bash
 # Or, to see "hello world!", use --verbose
 runem --verbose  # add --verbose to see the actual output
 ```
 
-To see how you can control your job use
-```sh
+To see how you can control your job use `--help`:
+```bash
 runem --help
 ```
 
-## 4.1 A more complete Quick start
+### 5.2. A more complete quick-start
 
 Here's a simple setup for a python project.
 
-Notice that this specifies:
--  The `phases` to use, and their order:
-   - This shows how we can control tasks that edit the files can go before analysis 
-   - This reduces any false-negatives the jobs may generate from running multiple jobs that may contend for write-access on the same files
-   - NOTE: `phases` are an early-stage way:
-     - To implement dependency chaining
-       - There is no dependency linking between jobs, yet.
-     - To manage resources
-       - For example, if you have a task which is threaded and/or memory heavy, you may want to put that into its own phase to get faster output.
-- `tags` to allow control over which jobs to run.
-  - Also which files to pass to jobs.
-- File-filters to detect which files the job operate on.
-  - NOTE: this is a WIP feature
-- Uses job-options:
-   - Allowing a python-function-job to control it's sub-task/processes.
--  If you use `--help` you will see a summary of all controls available.
+#### 5.2.1. A simple `.runem.yml`
 
 ```yml
 - config:
@@ -157,14 +169,26 @@ Notice that this specifies:
         - py format
 ```
 
-The following python file accompanies the above configuration and does slightly more advanced work. The file contains:
-- a single job.
-- the job linearises edit tasks that would otherwise contend for write-access to the files they operate on.
-  - formatting and doc-generation both edit files, conforming them to the coding standard.
-- uses `options` (see the config section) to control whether to:
-  - use `check-only` mode for CiCd, modifying the command-line switched passed down to the sub-commands.
-  - control whether `python-black` and/or/nor `docformatter` is run.
-- modifies the allowed-exit codes for `docformatter` to be `0` or `3`, matching the designed behaviour of that tool.
+Notice that this specifies:
+-  The `phases` to use, and their order:
+   - This shows how we can control tasks that edit the files can go before analysis
+   - This reduces any false-negatives the jobs may generate from running multiple jobs that may contend for write-access on the same files
+   - NOTE: `phases` are an early-stage way:
+     - To implement dependency chaining
+       - There is no dependency linking between jobs, yet.
+     - To manage resources
+       - For example, if you have a task which is threaded and/or memory heavy, you may want to put that into its own phase to get faster output.
+- `tags` to allow control over which jobs to run.
+  - Also which files to pass to jobs.
+- File-filters to detect which files the job operate on.
+  - NOTE: this is a WIP feature
+- Uses job-options:
+   - Allowing a python-function-job to control it's sub-task/processes.
+-  If you use `--help` you will see a summary of all controls available.
+
+#### 5.2.2. A simple python task
+
+Here's a simple python file describing a job. This accompanies the above `.runem.yml`.
 
 ```py
 # runem_hooks/py.py
@@ -232,23 +256,40 @@ def _job_py_code_reformat(
             **kwargs,
         )
 ```
+The above python file accompanies the above `.runem.yml` configuration and does slightly more advanced work. The file contains:
+- a single job.
+- the job itself linearises edit tasks that would otherwise contend for write-access to the files they operate on.
+  - formatting and doc-generation both edit files, conforming them to the coding standard.
+- uses `options` (see the config section) to control whether to:
+  - use `check-only` mode for CiCd, modifying the command-line switched passed down to the sub-commands.
+  - control whether `python-black` and/or/nor `docformatter` is run.
+- modifies the allowed-exit codes for `docformatter` to be `0` or `3`, matching the designed behaviour of that tool.
 
-## 5. Basic Usage
+## 6. Basic usage
 
 ```bash
-$ runem [--tags tag1,tag2,tag3] [--not-tags tag1,tag2,tag3] \
-        [--phases phaseX, phaseY] \
-        [--MY-OPTION] [--not-MY-OPTION] 
-#or
-$ python -m runem [--tags tag1,tag2,tag3] [--not-tags tag1,tag2,tag3] \
-                  [--phases phaseX, phaseY] \
-                  [--MY-OPTION] [--not-MY-OPTION] 
+# run all configured default jobs
+runem
+
+# ---- or ----
+
+# apply filters and controls
+runem [--tags tag1,tag2,tag3] [--not-tags tag1,tag2,tag3] \
+      [--phases phaseX, phaseY] \
+      [--MY-OPTION] [--not-MY-OPTION]
+
+# ---- or ----
+
+# run as a module
+python3 -m runem [--tags tag1,tag2,tag3] [--not-tags tag1,tag2,tag3] \
+                 [--phases phaseX, phaseY] \
+                 [--MY-OPTION] [--not-MY-OPTION]
 ```
 
-### 5.1. Tag filters
+### 6.1. Tag filters
 Jobs are tagged in the .runem.yml config file. Each unique tags is made available on the command-line. To see which tags are available use `--help`. To add a new tag extend the `tags` field in the `job` config.
 
-You can control which types of jobs to run via tags. Just tag the job in the config and then from the command-line you can add `--tags` or `--not-tags` to refine exactly which jobs will be run. 
+You can control which types of jobs to run via tags. Just tag the job in the config and then from the command-line you can add `--tags` or `--not-tags` to refine exactly which jobs will be run.
 
 To debug why a job is not selected pass `--verbose`.
 
@@ -262,19 +303,19 @@ runem --tags python
 
 `--not-tags` are subtractive filter out, that is any job with these tags are not run, even if they have tags set via the `--tags` switch. Meaning you can choose to run `python` tagged job but not run the `lint` jobs with `--tags python --not-tags lint`, and so on.
 
-#### 5.1.1. Run jobs only with the 'lint' tag:
+#### 6.1.1. Run jobs only with the 'lint' tag:
 
 ```bash
 runem --tags lint
 ```
 
-#### 5.1.2. If you want to lint all code _except_ nodejs code (and you have the appropriate tags):
+#### 6.1.2. If you want to lint all code _except_ nodejs code (and you have the appropriate tags):
 
 ```bash
 runem --tags lint --not-tags deprecated
 ```
 
-#### 5.1.3. Run fast checks on `pre-commit`
+#### 6.1.3. Run fast checks on `pre-commit`
 
 If you have fast jobs that tagged as appropriate for pre-commit hooks.
 
@@ -287,11 +328,11 @@ echo "runem --tags pre-commit" > scripts/git-hooks/pre-commit
 #	  hooksPath = ./scripts/git-hooks/husky/
 ```
 
-### 5.2. phase filters
+### 6.2. Phase filters
 
-Sometimes just want to run a specific phase, so you can focus on it and iterate quickly, within that context. 
+Sometimes just want to run a specific phase, so you can focus on it and iterate quickly, within that context.
 
-#### 5.2.1 Focus on a phase
+#### 6.2.1. Focus on a phase
 
 For example, if you have a `reformat` phase, you might want to run just `reformat` jobs phase whilst preparing a commit and are just preparing cosmetic changes e.g. updating comments, syntax, or docs.
 
@@ -299,7 +340,7 @@ For example, if you have a `reformat` phase, you might want to run just `reforma
 runem --phase reformat
 ```
 
-#### 5.2.2 Exclude slow phases temporarily
+#### 6.2.2. Exclude slow phases temporarily
 
 If you have 4 stages `bootstrap`, `pre-run`, `reformat`, `test` and `verify` phase, and are tightly iterating and focusing on the 'test-coverage' aspect of the test-phase, then you do not care about formatting as long as you can see your coverage results ASAP. However if your test-coverage starts passing then you will care about subsequent stages, so you can exclude the slower reformat-stage with the following and everything else will run.
 
@@ -309,11 +350,11 @@ runem --not-phase pre-run reformat
 
 **Note:** The `--tags` and `--not-tags` options can be used in combination to further refine task execution based on your requirements.
 
-## 6 Reports on your tasks
+## 7. Reports on your tasks
 
 Runem has a built-in support for reporting on tasks
 
-### 6.1 Task timings report
+### 7.1. Task timings report
 
 Runem will run the task and report how long the task took and whether it saved you any time, for example:
 
@@ -344,9 +385,9 @@ runem: report: coverage cobertura: ./reports/coverage_python/cobertura.xml
 runem: DONE: runem took: 8.820488s, saving you 13.268196s
 ```
 
-### 6.2 Bar-graphs with `termplotlib``
+### 7.2. Bar-graphs with `termplotlib`
 
-If you have `termplotlib` installed you will see
+If you have `termplotlib` installed you will see something like:
 
 ```text
 runem: Running 'pre-run' with 2 workers (of 8 max) processing 2 jobs
@@ -376,9 +417,10 @@ runem: DONE: runem took: 14.174612s, saving you 22.6414s
 
 NOTE: each phase's total system-time is reported above the timing for the individual jobs ran in that phase. This is NOT wall-clock time.
 
-## 7. Using Help to get an Overview of Your Jobs
+## 8. Using `--help`` to get an overview of your Jobs
 
-The `--help` switch will show you a full list of all the configured job-tasks, the tags and the override options, describing how to configure a specific run.
+The `--help` switch will show you a full list of all the configured job-tasks, the tags, and the override options. `--help` describes how to configure a specific run for *your* `.runem.yml` setup, and does NOT just document `runem` itself; it documents *your* workflow.
+
 ```bash
 $ python -m runem --help
 #or
@@ -463,7 +505,7 @@ job-param overrides:
 ```
 </details>
 
-## 8. Configuration
+## 9. Configuration
 
 `runem` searches for `.runem.yml` and will pre-load the command-line options with
 
@@ -472,9 +514,9 @@ Configuration is Yaml and consists of two main configurations, `config` and `job
 - `config` describes how the jobs should be run.
 - each `job`  entry describe a job-task, such and running unit-tests, linting or running any other type of command.
 
-### 8.1. `config` - Run 'em global config
+### 9.1. `config` - Run 'em global config
 
-- **phases:** 
+- **phases:**
   - *Description:* Specifies the different phases of the testing process, in the order they are to be run. Each job will be run under a specific phase.
   - *Values:* A list of strings representing "phases" such as pre-run (e.g. bootstrapping), edit (running py-black or prettifier or clang-tools), and analysis (unit-tests, coverage, linting).
 
@@ -492,12 +534,28 @@ Configuration is Yaml and consists of two main configurations, `config` and `job
   - **desc:** Provides a description of the option.
   - **alias:** (Optional) Provides an alias for the option if specified.
 
-### 8.2. `job` - Job config
+### 9.2. `job` - Job config
 - **job:**
   - *Description:* Represents a specific job task that is to be run asynchronously.
   - *Fields:*
+    - **command:**
+      - *Description:* a simple command line to be run. Commands will be run by the system exactly as they are written. Use `addr` for more complicated jobs. Commands are run in their associate `context`.
+      - *Example:
+        ```yaml
+        command: yarn run pretty
+        ```
+        ```yaml
+        command: python3 -m pylint **/*.py
+        ```
+        ```yaml
+        command: bash scripts/build_wrapper.sh
+        ```
+        ```yaml
+        command: clang-tidy -checks='*' -fix -header-filter='.*' your_file.cpp
+        ```
+
     - **addr:**
-      - *Description:* Specifies the address details of the job, including the file and function.
+      - *Description:* Specifies where a python function can be found. The python function will be loaded at runtime by `runem` and called with the `context`. The function recieves all information needed to run the job, including `label`, `JobConfig`, `verbose`, `options` and other run-time context.
       - *Subkeys:*
         - **file:** Indicates the file path of the job.
         - **function:** Indicates the function within the file that represents the job.
@@ -550,7 +608,7 @@ Configuration is Yaml and consists of two main configurations, `config` and `job
           cwd: src/subproject_4
           params:
             limitFilesToGroup: true
-        label: reformat 
+        label: reformat
         when:
           phase: edit
           tags:
@@ -558,34 +616,34 @@ Configuration is Yaml and consists of two main configurations, `config` and `job
             - subproject4
             - pretty
 
-## 9. Troubleshooting & Known issues
+## 10. Troubleshooting & Known issues
 
-### 9.1 I don't see bar graph timing reports!
+### 9.1. I don't see bar graph timing reports!
 We don't specify it in the output to reduce dependency installation for ci/cd. We may change this decision, especially as `halo` is a first-order dependency now.
 
 #### Solution:
-install `termplotlib`, 
+install `termplotlib`,
 
-### 9.2 I can't specify a dependency!
+### 10.2. I can't specify a dependency!
 Outside of `phases` we don't support direct dependency-chaining between tasks. We would like to do this at some point. PRs gladly accepted for this.
 
 #### Solution
 Use `phases` instead, or contribute a PR.
 
-### 9.3 Why is there so much output on errors, it looks duplicated?
+### 10.3. Why is there so much output on errors, it looks duplicated?
 We haven't looked at how we manage exception-handling with the python `multiprocessing` library, yet. Errors in `multiprocessing` procs tend to be re-reported in the calling process. PRs welcome.
 
 #### Solution
 Just look at one of the outputs.
 
-### 9.4 I can't see reports for job when errors happen!
-We try to show reports for completed tasks. If the task you're interested in doesn't show it probably hasn't been executed yet. Otherwise scroll up and you should see the reports and timings of *completed* tasks, if not, you may need to increase your buffer size.
+### 10.4. When errors happen I don't see reports for jobs!
+We try to show reports for completed tasks. If the task you're interested in doesn't show, it probably hasn't been executed yet. Otherwise scroll up and you should see the reports and timings of *completed* tasks, if not, you may need to increase your terminal's view-buffer size.
 
 #### Solution
-If you are focusing on one task and are only interested in how that task is performing/operating, use one of the many filtering options e.g. `--jobs "your job name" "another job name"`.
+If you are focusing on one task and are only interested in how that task is performing/operating, use one of the many filtering options e.g. `--jobs "your job name" "another job name"` or `--tags unittest`.
 
-### 9.5 I want to see log output for tasks in real-time, as they're happening!
-We don't stream stdout/stderr direct to console, or provide functionality for doing so, yet. Yes it would be a nice feature and we welcome PRs for it.
+### 10.5. I want to see log output for tasks in real-time, as they're happening!
+We don't stream stdout/stderr direct to console, or provide functionality for doing so, yet. However, we also believe that it would be a nice feature and welcome PRs.
 
 #### Solution
 On failure and with `--verbose` mode, the exact command is logged to console along with the environment that job was run in. You can copy/paste that command line to a terminal and run the command manually. The stdout/stderr will then be as you would get for that command. Refer to the documentation for that command.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ The name "runem" is derived from the fusion of "run" and "them," encapsulating t
   - [8. Configuration](#8-configuration)
     - [8.1. `config` - Run 'em global config](#81-config---run-em-global-config)
     - [8.2. `job` - Job config](#82-job---job-config)
+  - [9. Troubleshooting \& Known issues](#9-troubleshooting--known-issues)
+    - [9.1 I don't see bar graph timing reports!](#91-i-dont-see-bar-graph-timing-reports)
+      - [Solution:](#solution)
+    - [9.2 I can't specify a dependency!](#92-i-cant-specify-a-dependency)
+      - [Solution](#solution-1)
+    - [9.3 Why is there so much output on errors, it looks duplicated?](#93-why-is-there-so-much-output-on-errors-it-looks-duplicated)
+      - [Solution](#solution-2)
+    - [9.4 I can't see reports for job when errors happen!](#94-i-cant-see-reports-for-job-when-errors-happen)
+      - [Solution](#solution-3)
+    - [9.5 I want to see log output for tasks in real-time, as they're happening!](#95-i-want-to-see-log-output-for-tasks-in-real-time-as-theyre-happening)
+      - [Solution](#solution-4)
 - [Contributing to and supporting runem](#contributing-to-and-supporting-runem)
   - [Development](#development)
   - [Sponsor](#sponsor)
@@ -547,6 +558,37 @@ Configuration is Yaml and consists of two main configurations, `config` and `job
             - subproject4
             - pretty
 
+## 9. Troubleshooting & Known issues
+
+### 9.1 I don't see bar graph timing reports!
+We don't specify it in the output to reduce dependency installation for ci/cd. We may change this decision, especially as `halo` is a first-order dependency now.
+
+#### Solution:
+install `termplotlib`, 
+
+### 9.2 I can't specify a dependency!
+Outside of `phases` we don't support direct dependency-chaining between tasks. We would like to do this at some point. PRs gladly accepted for this.
+
+#### Solution
+Use `phases` instead, or contribute a PR.
+
+### 9.3 Why is there so much output on errors, it looks duplicated?
+We haven't looked at how we manage exception-handling with the python `multiprocessing` library, yet. Errors in `multiprocessing` procs tend to be re-reported in the calling process. PRs welcome.
+
+#### Solution
+Just look at one of the outputs.
+
+### 9.4 I can't see reports for job when errors happen!
+We try to show reports for completed tasks. If the task you're interested in doesn't show it probably hasn't been executed yet. Otherwise scroll up and you should see the reports and timings of *completed* tasks, if not, you may need to increase your buffer size.
+
+#### Solution
+If you are focusing on one task and are only interested in how that task is performing/operating, use one of the many filtering options e.g. `--jobs "your job name" "another job name"`.
+
+### 9.5 I want to see log output for tasks in real-time, as they're happening!
+We don't stream stdout/stderr direct to console, or provide functionality for doing so, yet. Yes it would be a nice feature and we welcome PRs for it.
+
+#### Solution
+On failure and with `--verbose` mode, the exact command is logged to console along with the environment that job was run in. You can copy/paste that command line to a terminal and run the command manually. The stdout/stderr will then be as you would get for that command. Refer to the documentation for that command.
 
 ---
 # Contributing to and supporting runem

--- a/cspell.json
+++ b/cspell.json
@@ -24,6 +24,7 @@
     "fixup", // used alot to denot fixing an issue
     "funcs", // convenience for functions
     "getfixturevalue", // pytest
+    "inplace", // switch for doc-formatter
     "isort", // python module
     "kwargs", // key-word args shorthand
     "linters", // collection of linting tools

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 
 from runem.config_metadata import ConfigMetadata
-from runem.job_wrapper_python import get_job_wrapper
+from runem.job_wrapper import get_job_wrapper
 from runem.log import log
 from runem.types import (
     Config,

--- a/runem/job.py
+++ b/runem/job.py
@@ -1,12 +1,6 @@
 import typing
 
-from runem.types import (
-    UNTAGGED_TAG,
-    FilePathList,
-    FilePathListLookup,
-    JobConfig,
-    JobTags,
-)
+from runem.types import FilePathList, FilePathListLookup, JobConfig, JobTags, JobWhen
 
 
 class NoJobName(ValueError):
@@ -34,8 +28,14 @@ class Job:
         if "when" not in job or "tags" not in job["when"]:
             # handle the special case where we have No tags
             return None
-        job_tags: JobTags = set(job.get("when", {}).get("tags", [UNTAGGED_TAG]))
-        return job_tags
+        when: JobWhen = job.get("when", {})
+        try:
+            job_tags: JobTags = when["tags"]
+        except KeyError:
+            # no tags, return None
+            return None
+        # have valid tags, coerce them to be a set-type and return
+        return set(job_tags)
 
     @staticmethod
     def get_job_files(

--- a/runem/job.py
+++ b/runem/job.py
@@ -1,0 +1,91 @@
+import typing
+
+from runem.types import (
+    UNTAGGED_TAG,
+    FilePathList,
+    FilePathListLookup,
+    JobConfig,
+    JobTags,
+)
+
+
+class NoJobName(ValueError):
+    """The job-config does not contain a label and can't be coerced to crate one."""
+
+    pass
+
+
+class Job:
+    """A class with utility functions for jobs.
+
+    Currently these are static but eventually will be members
+    """
+
+    @staticmethod
+    def get_job_tags(job: JobConfig) -> typing.Optional[JobTags]:
+        """Returns the tags for this job or None if the tags key is missing.
+
+        In practice None means:
+        - get all files
+        - always run job
+
+        TODO: make a non-static member function
+        """
+        if "when" not in job or "tags" not in job["when"]:
+            # handle the special case where we have No tags
+            return None
+        job_tags: JobTags = set(job.get("when", {}).get("tags", [UNTAGGED_TAG]))
+        return job_tags
+
+    @staticmethod
+    def get_job_files(
+        file_lists: FilePathListLookup, job_tags: typing.Optional[JobTags]
+    ) -> FilePathList:
+        """Return the list of files for the job-associated tags.
+
+        TODO: support no files-groups being defined i.e. switch to all files
+              being used (maybe).
+
+        FIXME: this is a bad design choice that will need revisiting. I guess
+               the options are to:
+            1. Have file-list-tags (ugh)
+            2. Keep associating tags with file-sets
+            3. Add additional filtering based on cwd (ugh)
+
+            #1 is probably the winner but we'll ponder on it before deciding.
+
+        TODO: make a non-static member function
+        """
+
+        # default to all file-tags
+        tags_for_files: typing.Iterable[str] = file_lists.keys()
+        use_default_tags: bool = job_tags is None
+        if not use_default_tags:
+            # use whatever tags are in the config, even if empty
+            assert job_tags  # for mypy
+            tags_for_files = job_tags
+        file_list: FilePathList = []
+        for tag in tags_for_files:
+            if tag in file_lists:
+                file_list.extend(file_lists[tag])
+        return sorted(file_list)
+
+    @staticmethod
+    def get_job_name(job: JobConfig) -> str:
+        """Returns a name to use for a given job config.
+
+        TODO: make a non-static member function
+        """
+
+        # First try one of the following keys.
+        valid_name_keys = ("label", "command")
+        for candidate in valid_name_keys:
+            name: typing.Optional[str] = job.get(candidate, None)  # type: ignore # NO_COMMIT
+            if name:
+                return name
+
+        # The try the python-wrapper address
+        try:
+            return f'{job["addr"]["file"]}.{job["addr"]["function"]}'
+        except KeyError:
+            raise NoJobName()  # pylint: disable=raise-missing-from

--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from timeit import default_timer as timer
 
 from runem.config_metadata import ConfigMetadata
-from runem.job_wrapper_python import get_job_wrapper
+from runem.job_wrapper import get_job_wrapper
 from runem.log import log
 from runem.types import (
     FilePathList,

--- a/runem/job_filter.py
+++ b/runem/job_filter.py
@@ -2,6 +2,7 @@ import typing
 from collections import defaultdict
 
 from runem.config_metadata import ConfigMetadata
+from runem.job import Job
 from runem.log import log
 from runem.types import (
     JobConfig,
@@ -12,6 +13,47 @@ from runem.types import (
     PhaseName,
 )
 from runem.utils import printable_set
+
+
+def _should_filter_out_by_tags(
+    job: JobConfig,
+    tags: JobTags,
+    tags_to_avoid: JobTags,
+    verbose: bool,
+) -> bool:
+    job_tags: typing.Optional[JobTags] = Job.get_job_tags(job)
+    opted_into_tag_filtering: bool = job_tags is not None
+    if not opted_into_tag_filtering:
+        # TODO: should we also consider 'empty' tags and being opted out of
+        #       tag-filtering?
+        return False
+
+    # the config for the command has tags, use them
+    assert job_tags is not None  # for mypy
+    matching_tags = job_tags.intersection(tags)
+    if not matching_tags:
+        if verbose:
+            log(
+                (
+                    f"not running job '{job['label']}' because it doesn't have "
+                    f"any of the following tags: {printable_set(tags)}"
+                )
+            )
+        return True  # filter-out this job
+
+    has_tags_to_avoid = job_tags.intersection(tags_to_avoid)
+    if has_tags_to_avoid:
+        if verbose:
+            log(
+                (
+                    f"not running job '{job['label']}' because it contains the "
+                    f"following tags: {printable_set(has_tags_to_avoid)}"
+                )
+            )
+        return True  # filter-out this job
+
+    # no filter criteria met, filter-in the job i.e. run the job
+    return False
 
 
 def _get_jobs_matching(
@@ -27,35 +69,15 @@ def _get_jobs_matching(
 
     job: JobConfig
     for job in phase_jobs:
-        job_tags = set(job["when"]["tags"])
-        matching_tags = job_tags.intersection(tags)
-        if not matching_tags:
-            if verbose:
-                log(
-                    (
-                        f"not running job '{job['label']}' because it doesn't have "
-                        f"any of the following tags: {printable_set(tags)}"
-                    )
-                )
+        if _should_filter_out_by_tags(job, tags, tags_to_avoid, verbose):
             continue
 
-        if job["label"] not in job_names:
+        if Job.get_job_name(job) not in job_names:
             if verbose:
                 log(
                     (
                         f"not running job '{job['label']}' because it isn't in the "
                         f"list of job names. See --jobs and --not-jobs"
-                    )
-                )
-            continue
-
-        has_tags_to_avoid = job_tags.intersection(tags_to_avoid)
-        if has_tags_to_avoid:
-            if verbose:
-                log(
-                    (
-                        f"not running job '{job['label']}' because it contains the "
-                        f"following tags: {printable_set(has_tags_to_avoid)}"
                     )
                 )
             continue
@@ -114,7 +136,9 @@ def filter_jobs(  # noqa: C901
 
         if verbose:
             log((f"will run {len(filtered_jobs[phase])} jobs for phase '{phase}'"))
-            job_names: JobNames = {job["label"] for job in filtered_jobs[phase]}
+            job_names: JobNames = {
+                Job.get_job_name(job) for job in filtered_jobs[phase]
+            }
             log(f"\t{printable_set(job_names)}")
 
     return filtered_jobs

--- a/runem/job_filter.py
+++ b/runem/job_filter.py
@@ -72,11 +72,12 @@ def _get_jobs_matching(
         if _should_filter_out_by_tags(job, tags, tags_to_avoid, verbose):
             continue
 
-        if Job.get_job_name(job) not in job_names:
+        job_name: str = Job.get_job_name(job)
+        if job_name not in job_names:
             if verbose:
                 log(
                     (
-                        f"not running job '{job['label']}' because it isn't in the "
+                        f"not running job '{job_name}' because it isn't in the "
                         f"list of job names. See --jobs and --not-jobs"
                     )
                 )

--- a/runem/job_runner_simple_command.py
+++ b/runem/job_runner_simple_command.py
@@ -1,0 +1,26 @@
+import shlex
+import typing
+
+from runem.run_command import run_command
+from runem.types import JobConfig
+
+
+def job_runner_simple_command(
+    **kwargs: typing.Any,
+) -> None:
+    """Parses the command and tries to run it via the system.
+
+    Commands inherit the environment.
+    """
+    # assume we have the job.command entry, allowing KeyError to propagate up
+    job_config: JobConfig = kwargs["job"]
+    command_string: str = job_config["command"]
+
+    # use shlex to handle parsing of the command string, a non-trivial problem.
+    result = shlex.split(command_string)
+
+    # preserve quotes for consistent handling of strings and avoid the "word
+    # splitting" problem for unix-like shells.
+    result_with_quotes = [f'"{token}"' if " " in token else token for token in result]
+
+    run_command(cmd=result_with_quotes, **kwargs)

--- a/runem/job_wrapper.py
+++ b/runem/job_wrapper.py
@@ -1,9 +1,19 @@
 import pathlib
 
+from runem.job_runner_simple_command import job_runner_simple_command
 from runem.job_wrapper_python import get_job_wrapper_py_func
 from runem.types import JobConfig, JobFunction
 
 
 def get_job_wrapper(job_config: JobConfig, cfg_filepath: pathlib.Path) -> JobFunction:
-    """Returns a pythonic job-wrapper function that can be called to run a job."""
+    """Given a job-description determines the job-runner, returning it as a function.
+
+    NOTE: Side-effects: also re-addressed the job-config in the case of functions see
+          get_job_function.
+    """
+    if "command" in job_config:
+        return job_runner_simple_command  # type: ignore # NO_COMMIT
+
+    # if we do not have a simple command address assume we have just an addressed
+    # function
     return get_job_wrapper_py_func(job_config, cfg_filepath)

--- a/runem/job_wrapper.py
+++ b/runem/job_wrapper.py
@@ -1,0 +1,9 @@
+import pathlib
+
+from runem.job_wrapper_python import get_job_wrapper_py_func
+from runem.types import JobConfig, JobFunction
+
+
+def get_job_wrapper(job_config: JobConfig, cfg_filepath: pathlib.Path) -> JobFunction:
+    """Returns a pythonic job-wrapper function that can be called to run a job."""
+    return get_job_wrapper_py_func(job_config, cfg_filepath)

--- a/runem/job_wrapper_python.py
+++ b/runem/job_wrapper_python.py
@@ -120,8 +120,3 @@ def get_job_wrapper_py_func(
     # re-write the job-config file-path for the module with the one that worked
     job_config["addr"]["file"] = str(module_file_path)
     return function
-
-
-def get_job_wrapper(job_config: JobConfig, cfg_filepath: pathlib.Path) -> JobFunction:
-    """Returns a pythonic job-wrapper function that can be called to run a job."""
-    return get_job_wrapper_py_func(job_config, cfg_filepath)

--- a/runem/job_wrapper_python.py
+++ b/runem/job_wrapper_python.py
@@ -88,7 +88,7 @@ def _find_job_module(cfg_filepath: pathlib.Path, module_file_path: str) -> pathl
 def get_job_wrapper_py_func(
     job_config: JobConfig, cfg_filepath: pathlib.Path
 ) -> JobFunction:
-    """Given a job-description dynamically loads the job-function so we can call it.
+    """For a job, dynamically loads the associated python job-function.
 
     Side-effects: also re-addressed the job-config.
     """

--- a/runem/job_wrapper_python.py
+++ b/runem/job_wrapper_python.py
@@ -85,7 +85,9 @@ def _find_job_module(cfg_filepath: pathlib.Path, module_file_path: str) -> pathl
     return module_path.relative_to(cfg_filepath.parent.absolute())
 
 
-def get_job_wrapper(job_config: JobConfig, cfg_filepath: pathlib.Path) -> JobFunction:
+def get_job_wrapper_py_func(
+    job_config: JobConfig, cfg_filepath: pathlib.Path
+) -> JobFunction:
     """Given a job-description dynamically loads the job-function so we can call it.
 
     Side-effects: also re-addressed the job-config.
@@ -118,3 +120,8 @@ def get_job_wrapper(job_config: JobConfig, cfg_filepath: pathlib.Path) -> JobFun
     # re-write the job-config file-path for the module with the one that worked
     job_config["addr"]["file"] = str(module_file_path)
     return function
+
+
+def get_job_wrapper(job_config: JobConfig, cfg_filepath: pathlib.Path) -> JobFunction:
+    """Returns a pythonic job-wrapper function that can be called to run a job."""
+    return get_job_wrapper_py_func(job_config, cfg_filepath)

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -38,6 +38,7 @@ from runem.config import load_config
 from runem.config_metadata import ConfigMetadata
 from runem.config_parse import parse_config
 from runem.files import find_files
+from runem.job import Job
 from runem.job_execute import job_execute
 from runem.job_filter import filter_jobs
 from runem.log import log
@@ -105,7 +106,7 @@ def _update_progress(
         spinner.start()
 
     # The set of all job labels, and the set of completed jobs
-    all_job_names: typing.Set[str] = {job["label"] for job in all_jobs}
+    all_job_names: typing.Set[str] = {Job.get_job_name(job) for job in all_jobs}
     completed_jobs: typing.Set[str] = set()
 
     # This dataset is used to track changes between iterations

--- a/runem/types.py
+++ b/runem/types.py
@@ -100,7 +100,7 @@ class JobContextConfig(typing.TypedDict, total=False):
     cwd: typing.Optional[typing.Union[str, typing.List[str]]]
 
 
-class JobWhen(typing.TypedDict):
+class JobWhen(typing.TypedDict, total=False):
     """Configures WHEN to call the callable i.e. priority."""
 
     tags: JobTags  # the job tags - used for filtering job-types
@@ -186,5 +186,3 @@ class JobSerialisedConfig(typing.TypedDict):
 ConfigNodes = typing.Union[GlobalSerialisedConfig, JobSerialisedConfig]
 # The config format as it is serialised to/from disk
 Config = typing.List[ConfigNodes]
-
-UNTAGGED_TAG: JobTag = "no_tag"

--- a/runem/types.py
+++ b/runem/types.py
@@ -111,10 +111,13 @@ class JobConfig(typing.TypedDict, total=False):
     """A dict that defines a job to be run.
 
     It consists of the label, address, context and filter information
+
+    TODO: make a class variant of this
     """
 
     label: JobName  # the name of the job
     addr: JobAddressConfig  # which callable to call
+    command: str  # a one-liner command to be run
     ctx: typing.Optional[JobContextConfig]  # how to call the callable
     when: JobWhen  # when to call the job
 
@@ -183,3 +186,5 @@ class JobSerialisedConfig(typing.TypedDict):
 ConfigNodes = typing.Union[GlobalSerialisedConfig, JobSerialisedConfig]
 # The config format as it is serialised to/from disk
 Config = typing.List[ConfigNodes]
+
+UNTAGGED_TAG: JobTag = "no_tag"

--- a/scripts/test_hooks/json_validators.py
+++ b/scripts/test_hooks/json_validators.py
@@ -10,7 +10,12 @@ def _json_validate(
 ) -> None:
     label = kwargs["label"]
     json_files: FilePathList = kwargs["file_list"]
-    json_with_comments = ("cspell.json", "tsconfig.spec.json", "launch.json")
+    json_with_comments = (
+        "cspell.json",
+        "tsconfig.spec.json",
+        "launch.json",
+        "settings.json",
+    )
     for json_file in json_files:
         json_path = pathlib.Path(json_file)
         if not json_path.exists():

--- a/scripts/test_hooks/yarn.py
+++ b/scripts/test_hooks/yarn.py
@@ -4,13 +4,6 @@ from runem.run_command import run_command
 from runem.types import Options
 
 
-def _job_spellcheck(
-    **kwargs: typing.Any,
-) -> None:
-    es_spellcheck = ["yarn", "run", "spellCheck"]
-    run_command(cmd=es_spellcheck, **kwargs)
-
-
 def _job_prettier(
     **kwargs: typing.Any,
 ) -> None:

--- a/tests/data/help_output.txt
+++ b/tests/data/help_output.txt
@@ -1,13 +1,16 @@
-usage: -c [-h] [--jobs JOBS [JOBS ...]]
-          [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]]
-          [--phases PHASES [PHASES ...]]
-          [--not-phases PHASES_EXCLUDED [PHASES_EXCLUDED ...]]
-          [--tags TAGS [TAGS ...]]
-          [--not-tags TAGS_EXCLUDED [TAGS_EXCLUDED ...]]
-          [--dummy-option-1---complete-option]
-          [--no-dummy-option-1---complete-option] [--dummy-option-2---minimal]
-          [--no-dummy-option-2---minimal] [--call-graphs | --no-call-graphs]
-          [--procs PROCS] [--root ROOT_DIR] [--verbose | --no-verbose | -v]
+runem: WARNING: no phase found for 'echo "hello world!"', using 'dummy phase 1'
+usage: __main__.py [-h] [--jobs JOBS [JOBS ...]]
+                   [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]]
+                   [--phases PHASES [PHASES ...]]
+                   [--not-phases PHASES_EXCLUDED [PHASES_EXCLUDED ...]]
+                   [--tags TAGS [TAGS ...]]
+                   [--not-tags TAGS_EXCLUDED [TAGS_EXCLUDED ...]]
+                   [--dummy-option-1---complete-option]
+                   [--no-dummy-option-1---complete-option]
+                   [--dummy-option-2---minimal]
+                   [--no-dummy-option-2---minimal]
+                   [--call-graphs | --no-call-graphs] [--procs PROCS]
+                   [--root ROOT_DIR] [--verbose | --no-verbose | -v]
 
 Runs the Lursight Lang test-suite
 
@@ -26,11 +29,12 @@ jobs:
   --jobs JOBS [JOBS ...]
                         List of job-names to run the given jobs. Other filters
                         will modify this list. Defaults to 'dummy job label
-                        1', 'dummy job label 2'
+                        1', 'dummy job label 2', 'echo "hello world!"', 'hello
+                        world'
   --not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]
                         List of job-names to NOT run. Defaults to empty.
                         Available options are: 'dummy job label 1', 'dummy job
-                        label 2'
+                        label 2', 'echo "hello world!"', 'hello world'
 
 phases:
   --phases PHASES [PHASES ...]

--- a/tests/test_config_parse.py
+++ b/tests/test_config_parse.py
@@ -183,7 +183,7 @@ def test_parse_job_config_throws_on_missing_key() -> None:
     jobs_by_phase: PhaseGroupedJobs = defaultdict(list)
     job_names: JobNames = set(("reformat py",))
     phases: JobPhases = set()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as err_info:
         parse_job_config(
             cfg_filepath=pathlib.Path(__file__),
             job=job_config,
@@ -192,6 +192,7 @@ def test_parse_job_config_throws_on_missing_key() -> None:
             in_out_job_names=job_names,
             in_out_phases=phases,
         )
+    assert str(err_info.value).startswith(("job config entry is missing 'label' data"))
 
 
 def test_parse_global_config_empty() -> None:

--- a/tests/test_config_parse.py
+++ b/tests/test_config_parse.py
@@ -489,12 +489,12 @@ def test_parse_job_with_tags(mock_get_job_wrapper: Mock) -> None:
     """Test case where job_tags is not empty."""
     cfg_filepath = pathlib.Path(__file__)
     job_config: JobConfig = {
-        "label": "Job1",  # a
-        "when": {  # type: ignore[typeddict-item]
-            "tags": [
-                "tag1",  # t1
+        "label": "Job1",
+        "when": {
+            "tags": {
+                "tag1",
                 "tag2",
-            ]
+            }
         },
     }
     in_out_tags: JobTags = set()
@@ -533,8 +533,8 @@ def test_parse_job_without_tags(mock_get_job_wrapper: Mock) -> None:
     cfg_filepath = pathlib.Path(__file__)
     job_config: JobConfig = {
         "label": "Job2",
-        "when": {  # type: ignore[typeddict-item]
-            "phase": "phase1",  # phase
+        "when": {
+            "phase": "phase1",
         },
     }
     in_out_tags: JobTags = set()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,0 +1,102 @@
+import typing
+from collections import defaultdict
+
+import pytest
+
+from runem.job import Job, NoJobName
+from runem.types import FilePathList, FilePathListLookup, JobConfig, JobTags
+
+
+@pytest.mark.parametrize(
+    "job_config, expected_result",
+    [
+        ({"when": {}}, None),
+        ({"when": {"tags": []}}, set()),
+        ({"when": {"tags": ["tag1"]}}, {"tag1"}),
+        ({"when": {"tags": ["tag1", "tag2", "tag3"]}}, {"tag1", "tag2", "tag3"}),
+        ({}, None),
+        ({"when": {}}, None),
+    ],
+)
+def test_get_job_tags(
+    job_config: JobConfig, expected_result: typing.Optional[JobTags]
+) -> None:
+    result: typing.Optional[JobTags] = Job.get_job_tags(job_config)
+    assert result == expected_result
+
+
+@pytest.fixture(name="file_lists")
+def file_lists_fixture() -> FilePathListLookup:
+    """Define a sample file_lists dictionary for testing."""
+    file_lists: FilePathListLookup = defaultdict(list)
+    file_lists.update(
+        {
+            "tag1": ["file1.txt", "file2.txt"],
+            "tag2": ["file3.txt", "file4.txt"],
+            "tag3": ["file5.txt"],
+        }
+    )
+    return file_lists
+
+
+@pytest.mark.parametrize(
+    "job_tags, expected_result",
+    [
+        (None, ["file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt"]),
+        ({"tag1"}, ["file1.txt", "file2.txt"]),
+        ({"tag2", "tag3"}, ["file3.txt", "file4.txt", "file5.txt"]),
+        ({"tag4"}, []),
+    ],
+)
+def test_get_job_files(
+    file_lists: FilePathListLookup,
+    job_tags: typing.Optional[JobTags],
+    expected_result: FilePathList,
+) -> None:
+    """Test cases for the get_job_files method."""
+    # Call the method under test
+    result: FilePathList = Job.get_job_files(file_lists, job_tags)
+
+    # Assert the result matches the expected outcome
+    assert result == sorted(expected_result)
+
+
+def test_get_job_name() -> None:
+    """Test case for the get_job_name method."""
+    # Define a sample job configuration for testing
+    job_config: JobConfig = {
+        "label": "Job 1",
+        "command": "python script.py",
+        "addr": {"file": "script.py", "function": "main"},
+    }
+
+    # Call the method under test
+    result: str = Job.get_job_name(job_config)
+
+    # Assert the result matches the expected outcome
+    assert result == "Job 1"
+
+
+def test_get_job_name_command_key() -> None:
+    """Test case for the get_job_name method when using the "command" key."""
+    job_config: JobConfig = {
+        "command": "python script.py",
+    }
+    result: str = Job.get_job_name(job_config)
+    assert result == "python script.py"
+
+
+def test_get_job_name_addr_key() -> None:
+    """Test case for the get_job_name method when using the "addr" key."""
+    job_config: JobConfig = {
+        "addr": {"file": "script.py", "function": "main"},
+    }
+    result: str = Job.get_job_name(job_config)
+    assert result == "script.py.main"
+
+
+def test_get_job_name_invalid_config() -> None:
+    """Test case for the get_job_name method with an invalid configuration."""
+    job_config: JobConfig = {}
+    with pytest.raises(NoJobName):
+        Job.get_job_name(job_config)

--- a/tests/test_job_filter.py
+++ b/tests/test_job_filter.py
@@ -3,12 +3,13 @@ import pathlib
 from argparse import Namespace
 from collections import defaultdict
 from contextlib import redirect_stdout
+from unittest.mock import Mock, patch
 
 import pytest
 
 from runem.config_metadata import ConfigMetadata
-from runem.job_filter import filter_jobs
-from runem.types import JobConfig, PhaseGroupedJobs
+from runem.job_filter import _get_jobs_matching, _should_filter_out_by_tags, filter_jobs
+from runem.types import JobConfig, JobTags, PhaseGroupedJobs
 
 
 @pytest.mark.parametrize(
@@ -70,3 +71,115 @@ def test_runem_job_filters_work_with_no_tags(verbosity: bool) -> None:
         ]
     else:
         assert run_command_stdout == ""
+
+
+@pytest.mark.parametrize(
+    "verbosity",
+    [
+        True,
+        False,
+    ],
+)
+def test_should_filter_out_by_tags_with_tags_to_avoid(verbosity: bool) -> None:
+    """Test case where has_tags_to_avoid is not empty."""
+    job: JobConfig = {
+        "label": "Job1",
+        "when": {  # type: ignore[typeddict-item]
+            "tags": [
+                "tag1",  # dummy tag
+                "tag2",  # dummy tag
+            ]
+        },
+    }
+    tags: JobTags = {"tag1"}
+    tags_to_avoid: JobTags = {"tag1", "tag2"}
+
+    with io.StringIO() as buf, redirect_stdout(buf):
+        result: bool = _should_filter_out_by_tags(job, tags, tags_to_avoid, verbosity)
+        run_command_stdout = buf.getvalue().split("\n")
+
+    assert result is True
+    if not verbosity:
+        assert run_command_stdout == [""]
+    else:
+        assert run_command_stdout == [
+            "runem: not running job 'Job1' because it contains the following tags: "
+            "'tag1', 'tag2'",
+            "",
+        ]
+
+
+@pytest.mark.parametrize(
+    "verbosity",
+    [
+        True,
+        False,
+    ],
+)
+def test_should_filter_out_by_tags_without_tags_to_avoid(verbosity: bool) -> None:
+    """Test case where has_tags_to_avoid is empty."""
+    job: JobConfig = {
+        "label": "Job1",
+        "when": {  # type: ignore[typeddict-item]
+            "tags": [
+                "tag3",  # dummy tag
+                "tag4",  # dummy tag
+            ]
+        },
+    }
+    tags: JobTags = {"tag3"}
+    tags_to_avoid: JobTags = {"tag1", "tag2"}
+
+    with io.StringIO() as buf, redirect_stdout(buf):
+        result: bool = _should_filter_out_by_tags(job, tags, tags_to_avoid, verbosity)
+        run_command_stdout = buf.getvalue().split("\n")
+
+    if verbosity:
+        assert run_command_stdout == [""]
+    else:
+        assert run_command_stdout == [""]
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    "verbosity",
+    [
+        True,
+        False,
+    ],
+)
+@patch("runem.job_filter._should_filter_out_by_tags", return_value=False)
+@patch(
+    "runem.job_filter.Job.get_job_name", return_value=("intentionally not in job names")
+)
+def test_get_jobs_matching_with_tags_to_avoid(
+    mock_get_job_name: Mock,
+    mock_should_filter: Mock,
+    verbosity: bool,
+) -> None:
+    """Test case where has_tags_to_avoid is not empty."""
+    job: JobConfig = {
+        "label": "Job1",
+        "when": {"phase": "phase", "tags": {"tag1", "tag2"}},
+    }
+    tags: JobTags = {"tag1"}
+    tags_to_avoid: JobTags = {"tag1", "tag2"}
+    jobs: PhaseGroupedJobs = defaultdict(list)
+    jobs.update({"phase": [job]})
+
+    with io.StringIO() as buf, redirect_stdout(buf):
+        _get_jobs_matching(
+            "phase", {"job name 1"}, tags, tags_to_avoid, jobs, jobs, verbosity
+        )
+        run_command_stdout = buf.getvalue().split("\n")
+
+    if not verbosity:
+        assert run_command_stdout == [""]
+    else:
+        assert run_command_stdout == [
+            "runem: not running job 'Job1' because it isn't in the list of job names. See "
+            "--jobs and --not-jobs",
+            "",
+        ]
+    mock_get_job_name.assert_called_once()
+    mock_should_filter.assert_called_once()

--- a/tests/test_job_filter.py
+++ b/tests/test_job_filter.py
@@ -84,11 +84,11 @@ def test_should_filter_out_by_tags_with_tags_to_avoid(verbosity: bool) -> None:
     """Test case where has_tags_to_avoid is not empty."""
     job: JobConfig = {
         "label": "Job1",
-        "when": {  # type: ignore[typeddict-item]
-            "tags": [
-                "tag1",  # dummy tag
-                "tag2",  # dummy tag
-            ]
+        "when": {
+            "tags": {
+                "tag1",
+                "tag2",
+            }
         },
     }
     tags: JobTags = {"tag1"}
@@ -120,11 +120,11 @@ def test_should_filter_out_by_tags_without_tags_to_avoid(verbosity: bool) -> Non
     """Test case where has_tags_to_avoid is empty."""
     job: JobConfig = {
         "label": "Job1",
-        "when": {  # type: ignore[typeddict-item]
-            "tags": [
-                "tag3",  # dummy tag
-                "tag4",  # dummy tag
-            ]
+        "when": {
+            "tags": {
+                "tag3",
+                "tag4",
+            }
         },
     }
     tags: JobTags = {"tag3"}

--- a/tests/test_job_filter.py
+++ b/tests/test_job_filter.py
@@ -177,8 +177,10 @@ def test_get_jobs_matching_with_tags_to_avoid(
         assert run_command_stdout == [""]
     else:
         assert run_command_stdout == [
-            "runem: not running job 'Job1' because it isn't in the list of job names. See "
-            "--jobs and --not-jobs",
+            (
+                "runem: not running job 'intentionally not in job names' because it "
+                "isn't in the list of job names. See --jobs and --not-jobs"
+            ),
             "",
         ]
     mock_get_job_name.assert_called_once()

--- a/tests/test_job_runner_simple_command.py
+++ b/tests/test_job_runner_simple_command.py
@@ -1,0 +1,39 @@
+import io
+from contextlib import redirect_stdout
+from unittest.mock import Mock, patch
+
+from runem.job import Job
+from runem.job_runner_simple_command import job_runner_simple_command
+from runem.types import JobConfig
+
+
+@patch(
+    "runem.job_runner_simple_command.run_command",
+    # return_value=None,
+)
+def test_job_runner_simple_command(mock_run_command: Mock) -> None:
+    """Tests the basics of job_runner_simple_command."""
+    job_config: JobConfig = {
+        "command": "echo 'testing job_runner_simple_command'",
+    }
+    with io.StringIO() as buf, redirect_stdout(buf):
+        ret: None = job_runner_simple_command(  # type: ignore[func-returns-value]
+            # options=config_metadata.options,  # type: ignore
+            # file_list=file_list,
+            # procs=config_metadata.args.procs,
+            # root_path=root_path,
+            verbose=True,  # config_metadata.args.verbose,
+            # unpack useful data points from the job_config
+            label=Job.get_job_name(job_config),
+            job=job_config,
+        )
+        run_command_stdout = buf.getvalue()
+
+    assert ret is None
+    assert run_command_stdout.split("\n") == [""]
+    mock_run_command.assert_called_once_with(
+        cmd=["echo", '"testing job_runner_simple_command"'],
+        verbose=True,
+        label="echo 'testing job_runner_simple_command'",
+        job={"command": "echo 'testing job_runner_simple_command'"},
+    )

--- a/tests/test_job_wrapper.py
+++ b/tests/test_job_wrapper.py
@@ -1,0 +1,60 @@
+import pathlib
+from unittest.mock import Mock, patch
+
+from runem import job_runner_simple_command
+from runem.job_wrapper import get_job_wrapper
+from runem.types import JobConfig, JobFunction
+
+DUMMY_FUNCTION: JobFunction = (
+    "intentionally bad type as string to test call"  # type: ignore[assignment]
+)
+
+
+@patch(
+    "runem.job_wrapper.get_job_wrapper_py_func",
+    return_value=DUMMY_FUNCTION,
+)
+def test_get_job_wrapper_python_wrapper_job(mock_get_job_wrapper_py_func: Mock) -> None:
+    """Checks that the python wrapper job lookup is called."""
+    job_config: JobConfig = {
+        "addr": {
+            "file": __file__,
+            "function": "test_get_job_wrapper",
+        },
+        "label": "reformat py",
+        "when": {
+            "phase": "edit",
+            "tags": set(
+                (
+                    "py",
+                    "format",
+                )
+            ),
+        },
+    }
+    func_obj: JobFunction = get_job_wrapper(
+        job_config, cfg_filepath=pathlib.Path(__file__)
+    )
+    assert func_obj == DUMMY_FUNCTION
+
+    # with a python-function job-config if should call the mock once
+    mock_get_job_wrapper_py_func.assert_called_once()
+
+
+@patch(
+    "runem.job_wrapper.get_job_wrapper_py_func",
+    return_value=None,
+)
+def test_get_job_wrapper_simple_command_job(mock_get_job_wrapper_py_func: Mock) -> None:
+    """Checks that the job_runner_simple_command is returned for 'command' jobs."""
+    job_config: JobConfig = {
+        "command": "echo 'testing exec",
+    }
+    func_obj: JobFunction = get_job_wrapper(
+        job_config, cfg_filepath=pathlib.Path(__file__)
+    )
+
+    assert func_obj.__name__ == job_runner_simple_command.__name__.split(".")[1]
+
+    # with simple jobs the python wrapper lookup should NOT be called.
+    mock_get_job_wrapper_py_func.assert_not_called()

--- a/tests/test_job_wrapper_python.py
+++ b/tests/test_job_wrapper_python.py
@@ -4,8 +4,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from runem.job_wrapper import get_job_wrapper
-from runem.job_wrapper_python import _load_python_function_from_module
+from runem.job_wrapper_python import (
+    _load_python_function_from_module,
+    get_job_wrapper_py_func,
+)
 from runem.types import FunctionNotFound, JobConfig, JobFunction
 
 
@@ -35,7 +37,9 @@ def test_get_job_function(tmp_path: pathlib.Path) -> None:
             ),
         },
     }
-    loaded_func: JobFunction = get_job_wrapper(job_config, tmp_path / ".runem.yml")
+    loaded_func: JobFunction = get_job_wrapper_py_func(
+        job_config, tmp_path / ".runem.yml"
+    )
     assert loaded_func is not None
     assert loaded_func.__name__ == "test_get_job_function"
 
@@ -69,7 +73,7 @@ def test_get_job_function_handles_missing_function(tmp_path: pathlib.Path) -> No
 
     with pytest.raises(FunctionNotFound):
         # this should throw an exception
-        get_job_wrapper(job_config, tmp_path / ".runem.yml")
+        get_job_wrapper_py_func(job_config, tmp_path / ".runem.yml")
 
 
 def test_get_job_function_handles_missing_module(tmp_path: pathlib.Path) -> None:
@@ -100,7 +104,7 @@ def test_get_job_function_handles_missing_module(tmp_path: pathlib.Path) -> None
 
     with pytest.raises(FunctionNotFound):
         # this should throw an exception
-        get_job_wrapper(job_config, tmp_path / ".runem.yml")
+        get_job_wrapper_py_func(job_config, tmp_path / ".runem.yml")
 
 
 @patch(

--- a/tests/test_job_wrapper_python.py
+++ b/tests/test_job_wrapper_python.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from runem.job_wrapper_python import _load_python_function_from_module, get_job_wrapper
+from runem.job_wrapper import get_job_wrapper
+from runem.job_wrapper_python import _load_python_function_from_module
 from runem.types import FunctionNotFound, JobConfig, JobFunction
 
 

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -251,7 +251,14 @@ def _run_full_config_runem(
     return runem_stdout, error_raised
 
 
-def test_runem_with_full_config() -> None:
+@pytest.mark.parametrize(
+    "verbosity",
+    [
+        True,
+        False,
+    ],
+)
+def test_runem_with_full_config(verbosity: bool) -> None:
     """End-2-end test with a full config."""
     runem_cli_switches: typing.List[str] = []  # default switches/behaviour
     runem_stdout: typing.List[str]
@@ -260,28 +267,32 @@ def test_runem_with_full_config() -> None:
         runem_stdout,
         error_raised,
     ) = _run_full_config_runem(  # pylint: disable=no-value-for-parameter
-        runem_cli_switches=runem_cli_switches
+        runem_cli_switches=runem_cli_switches,
+        add_verbose_switch=verbosity,
     )
     assert error_raised is None
     _remove_x_of_y_workers_log(runem_stdout, phase="dummy phase 1")
     _remove_x_of_y_workers_log(runem_stdout, phase="dummy phase 2")
 
-    assert [
-        "runem: loaded config from [CONFIG PATH]",
-        "runem: found 1 batches, 1 'mock phase' files, ",
-        (
-            "runem: filtering for tags 'dummy tag 1', 'dummy tag 2', "
-            "'tag only on job 1', 'tag only on job 2'"
-        ),
-        "runem: will run 1 jobs for phase 'dummy phase 1'",
-        "runem: \t'dummy job label 1'",
-        "runem: will run 1 jobs for phase 'dummy phase 2'",
-        "runem: \t'dummy job label 2'",
-        "runem: Running Phase dummy phase 1",
-        "runem: Running Phase dummy phase 2",
-        # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
-        # "runem: Running 'dummy phase 2' with 1 workers processing 1 jobs",
-    ] == runem_stdout
+    if not verbosity:
+        assert [] == runem_stdout
+    else:
+        assert [
+            "runem: loaded config from [CONFIG PATH]",
+            "runem: found 1 batches, 1 'mock phase' files, ",
+            (
+                "runem: filtering for tags 'dummy tag 1', 'dummy tag 2', "
+                "'tag only on job 1', 'tag only on job 2'"
+            ),
+            "runem: will run 1 jobs for phase 'dummy phase 1'",
+            "runem: \t'dummy job label 1'",
+            "runem: will run 1 jobs for phase 'dummy phase 2'",
+            "runem: \t'dummy job label 2'",
+            "runem: Running Phase dummy phase 1",
+            "runem: Running Phase dummy phase 2",
+            # "runem: Running 'dummy phase 1' with 1 workers processing 1 jobs",
+            # "runem: Running 'dummy phase 2' with 1 workers processing 1 jobs",
+        ] == runem_stdout
 
 
 def test_runem_with_full_config_verbose() -> None:


### PR DESCRIPTION
### Summary :memo:

Adds a faster way to add basic tasks to `.runem.yml` configs

### Details
 feat(one-line-commands): adds simple-commands support to runem
    
This is quite a big refactor to add one-liners to .runem.yml, improving
the speed of on-boarding.

This means that the quick route to use should be a .runem.yml file that
looks something like:

```yml
- job:
    command: echo "hello world!"
```

instead of needing the following two files
```yml
- job:
    addr:
      file: path/to/file.py
      function: _function_name
    label: Job Label
    when:
      phase: some_phase
      tags:
        - tag
```

```py
from runem.run_command import run_command
from typing import Any

def _function_name(*kwargs:Any) -> None:
  run_command(["echo", "hello world"], **kwargs)
```

So, that's 2 lines instead of 15 so 87% less code just to get started.

Note that the key difference the 'address' and 'command' entries.

Also note that almost all of the options are now optional. This means
that the above function-addressed config can just be the following:

```yml
- job:
    addr:
      file: path/to/file.py
      function: _function_name
    label: Job Label
```

We use 'shlex' to avoid the word splitting problem when parsing commands
to be run.
