### PR TITLE
feat(ctx-dir-tag): add the last directory name from the 'cwd' path as a tag

### DIFF
--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -19,6 +19,7 @@ from runem.types import (
     JobPhases,
     JobSerialisedConfig,
     JobTags,
+    JobWhen,
     OptionConfigs,
     OrderedPhases,
     PhaseGroupedJobs,
@@ -138,6 +139,16 @@ def parse_job_config(
                     and specialised_job_for_cwd["ctx"]["cwd"]
                 ), specialised_job_for_cwd["ctx"].keys()
                 specialised_job_for_cwd["ctx"]["cwd"] = cwd
+
+                # add the last directory name from the 'cwd' path as a tag for
+                # easy reference to the job-task by its path
+                when: JobWhen = specialised_job_for_cwd.get("when", {})
+                when["tags"] = set(when.get("tags", set()))
+                cwd_path: pathlib.Path = pathlib.Path(cwd)
+                when["tags"].add(cwd_path.name)
+                specialised_job_for_cwd["when"] = when
+                specialised_job_for_cwd["ctx"]["cwd"] = cwd
+
                 # update the label to reflect the specialisation
                 specialised_job_for_cwd["label"] = f"{job['label']}({cwd})"
                 generated_jobs.append(specialised_job_for_cwd)

--- a/tests/test_config_parse.py
+++ b/tests/test_config_parse.py
@@ -110,7 +110,7 @@ def test_parse_job_config_handles_multiple_cwd() -> None:
         in_out_phases=phases,
         phase_order=phase_order,
     )
-    assert tags == {"format", "py"}
+    assert tags == {"a", "b", "format", "py"}, "tags should include the explicit"
     assert jobs_by_phase == {
         "edit": [
             {
@@ -120,7 +120,7 @@ def test_parse_job_config_handles_multiple_cwd() -> None:
                 },
                 "ctx": {"cwd": "path/a"},
                 "label": "reformat py(path/a)",
-                "when": {"phase": "edit", "tags": set(("py", "format"))},
+                "when": {"phase": "edit", "tags": set(("a", "py", "format"))},
             },
             {
                 "addr": {
@@ -129,7 +129,7 @@ def test_parse_job_config_handles_multiple_cwd() -> None:
                 },
                 "ctx": {"cwd": "path/b"},
                 "label": "reformat py(path/b)",
-                "when": {"phase": "edit", "tags": set(("py", "format"))},
+                "when": {"phase": "edit", "tags": set(("b", "py", "format"))},
             },
         ]
     }


### PR DESCRIPTION
### Summary :memo:

Add the last directory name from the 'cwd' path as a tag for easy reference to the job-task by its path

### Details

This means we can target specific jobs in specific directories.