### PR TITLE
feat(spinner-visibility-option): adds option to hide spinner

### DIFF
--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -137,6 +137,18 @@ def parse_args(
     )
 
     parser.add_argument(
+        "--spinner",
+        dest="show_spinner",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Whether to show the progress spinner or not. "
+            "Helps reduce log-spam in ci/cd."
+        ),
+        required=False,
+    )
+
+    parser.add_argument(
         "--verbose",
         "-v",
         dest="verbose",

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -88,7 +88,7 @@ def _update_progress(
     all_jobs: Jobs,
     is_running: ValueProxy[bool],
     num_workers: int,
-    show_spinner: bool = True,
+    show_spinner: bool,
 ) -> None:
     """Updates progress report periodically for running tasks.
 
@@ -154,6 +154,7 @@ def _process_jobs(
     in_out_job_run_metadatas: JobRunMetadatasByPhase,
     phase: PhaseName,
     jobs: Jobs,
+    show_spinner: bool,
 ) -> typing.Optional[BaseException]:
     """Execute each given job asynchronously.
 
@@ -195,6 +196,7 @@ def _process_jobs(
                 jobs,
                 is_running,
                 num_concurrent_procs,
+                show_spinner,
             ),
         )
         terminal_writer_process.start()
@@ -226,6 +228,7 @@ def _process_jobs_by_phase(
     file_lists: FilePathListLookup,
     filtered_jobs_by_phase: PhaseGroupedJobs,
     in_out_job_run_metadatas: JobRunMetadatasByPhase,
+    show_spinner: bool,
 ) -> typing.Optional[BaseException]:
     """Execute each job asynchronously, grouped by phase.
 
@@ -251,7 +254,12 @@ def _process_jobs_by_phase(
             log(f"Running Phase {phase}")
 
         failure_exception: typing.Optional[BaseException] = _process_jobs(
-            config_metadata, file_lists, in_out_job_run_metadatas, phase, jobs
+            config_metadata,
+            file_lists,
+            in_out_job_run_metadatas,
+            phase,
+            jobs,
+            show_spinner,
         )
         if failure_exception is not None:
             if config_metadata.args.verbose:
@@ -296,7 +304,11 @@ def _main(
     start = timer()
 
     failure_exception: typing.Optional[BaseException] = _process_jobs_by_phase(
-        config_metadata, file_lists, filtered_jobs_by_phase, job_run_metadatas
+        config_metadata,
+        file_lists,
+        filtered_jobs_by_phase,
+        job_run_metadatas,
+        show_spinner=config_metadata.args.show_spinner,
     )
 
     end = timer()

--- a/tests/data/help_output.txt
+++ b/tests/data/help_output.txt
@@ -1,16 +1,15 @@
 runem: WARNING: no phase found for 'echo "hello world!"', using 'dummy phase 1'
-usage: __main__.py [-h] [--jobs JOBS [JOBS ...]]
-                   [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]]
-                   [--phases PHASES [PHASES ...]]
-                   [--not-phases PHASES_EXCLUDED [PHASES_EXCLUDED ...]]
-                   [--tags TAGS [TAGS ...]]
-                   [--not-tags TAGS_EXCLUDED [TAGS_EXCLUDED ...]]
-                   [--dummy-option-1---complete-option]
-                   [--no-dummy-option-1---complete-option]
-                   [--dummy-option-2---minimal]
-                   [--no-dummy-option-2---minimal]
-                   [--call-graphs | --no-call-graphs] [--procs PROCS]
-                   [--root ROOT_DIR] [--verbose | --no-verbose | -v]
+usage: -c [-h] [--jobs JOBS [JOBS ...]]
+          [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]]
+          [--phases PHASES [PHASES ...]]
+          [--not-phases PHASES_EXCLUDED [PHASES_EXCLUDED ...]]
+          [--tags TAGS [TAGS ...]]
+          [--not-tags TAGS_EXCLUDED [TAGS_EXCLUDED ...]]
+          [--dummy-option-1---complete-option]
+          [--no-dummy-option-1---complete-option] [--dummy-option-2---minimal]
+          [--no-dummy-option-2---minimal] [--call-graphs | --no-call-graphs]
+          [--procs PROCS] [--root ROOT_DIR] [--spinner | --no-spinner]
+          [--verbose | --no-verbose | -v]
 
 Runs the Lursight Lang test-suite
 
@@ -23,6 +22,9 @@ Runs the Lursight Lang test-suite
   --root ROOT_DIR       which dir to use as the base-dir for testing, defaults
                         to directory containing the config
                         '[TEST_REPLACED_DIR]'
+  --spinner, --no-spinner
+                        Whether to show the progress spinner or not. Helps
+                        reduce log-spam in ci/cd. (default: True)
   --verbose, --no-verbose, -v
 
 jobs:

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -1354,6 +1354,7 @@ def test_process_jobs_by_phase_early_exits_with_exceptions(
             file_lists=file_lists,  # FilePathListLookup,
             filtered_jobs_by_phase=jobs_by_phase,  # PhaseGroupedJobs,
             in_out_job_run_metadatas={},  # JobRunMetadatasByPhase,
+            show_spinner=False,
         )
         runem_stdout = buf.getvalue().split("\n")
     assert mock_process_jobs.call_count == 1
@@ -1466,6 +1467,7 @@ def test_process_jobs_early_exits_with_exceptions(
             in_out_job_run_metadatas=defaultdict(list),  # JobRunMetadatasByPhase,
             phase="dummy phase 1",
             jobs=[job_phase_1_raises],  # Jobs
+            show_spinner=False,
         )
         runem_stdout = buf.getvalue().split("\n")
     assert mock_process_jobs.call_count == 1


### PR DESCRIPTION
### Summary :memo:

Adds option to hide spinner/progress as it causes ci/cd log-spam

### Details

As above, in ci/cd you might get hundreds or thousands of lines of duplicate output due to the animated progress spinner. This allow dowstream users to opt-out of show the spinner, reducing their log-spam.