### PR TITLE
Feat/stream stdout

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,8 @@
 # W503 is no-longer a pep8 standard warning
 #  It is now considered best practice to have binary operators on separate
 #  lines instead of lining up the variables starts.
-ignore = E203, W503, E231
+#  B036 seems to have cause false-positive in flake 7.0.0 and bugbear 24.2.6
+ignore = E203, W503, E231, B036
 
 # match python-black 80 + 10%, causes much shorter files
 max-line-length = 88

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,8 +2,8 @@
 black==23.11.0
 coverage==7.3.2
 docformatter==1.7.5
-flake8-bugbear==23.9.16
-flake8==6.1.0
+flake8-bugbear==24.2.6
+flake8==7.0.0
 gitchangelog==3.0.4
 isort==5.12.0
 mkdocs==1.5.3


### PR DESCRIPTION
### Summary :memo:
Supports larger sub-process buffer sizes by using Popen

### Details

This also allows us to stream the stdout to the console on verbose mode
Additionally, we upgrade flake8 version.