### PR TITLE
Feat/min version check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 halo
+packaging
 PyYAML

--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -6,6 +6,7 @@ import typing
 
 from runem.config_metadata import ConfigMetadata
 from runem.log import log
+from runem.runem_version import get_runem_version
 from runem.types import JobNames, OptionConfig, Options
 from runem.utils import printable_set
 
@@ -150,14 +151,29 @@ def parse_args(
 
     parser.add_argument(
         "--verbose",
-        "-v",
         dest="verbose",
+        help="runs runem in in verbose mode, and streams jobs stdout/stderr to console",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        required=False,
+    )
+
+    parser.add_argument(
+        "--version",
+        "-v",
+        dest="show_version_and_exit",
+        help="show the version of runem and exit",
         action=argparse.BooleanOptionalAction,
         default=False,
         required=False,
     )
 
     args = parser.parse_args(argv[1:])
+
+    if args.show_version_and_exit:
+        log(str(get_runem_version()), decorate=False)
+        # cleanly exit
+        sys.exit(0)
 
     options: Options = initialise_options(config_metadata, args)
 

--- a/runem/runem_version.py
+++ b/runem/runem_version.py
@@ -1,0 +1,10 @@
+import pathlib
+
+from packaging.version import Version
+
+
+def get_runem_version() -> Version:
+    """Returns the Version object representing runem's current version."""
+    return Version(
+        (pathlib.Path(__file__).parent / "VERSION").read_text("utf8").strip()
+    )

--- a/runem/types.py
+++ b/runem/types.py
@@ -159,6 +159,9 @@ class GlobalConfig(typing.TypedDict):
     # Job will receive the super-set of files for all that job's tags.
     files: typing.Optional[typing.List[TagFileFilterSerialised]]
 
+    # Which minimal version of runem does this config support?
+    min_version: typing.Optional[str]
+
 
 class GlobalSerialisedConfig(typing.TypedDict):
     """Intended to make reading a config file easier.

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
     long_description_content_type="text/markdown",
     author="lursight",
     packages=find_packages(exclude=["tests", ".github"]),
+    package_data={
+        "runem": ["VERSION"],  # Specify the path to VERSION within the package
+    },
     install_requires=read_requirements("requirements.txt"),
     entry_points={"console_scripts": ["runem = runem.__main__:main"]},
     extras_require={"test": read_requirements("requirements-test.txt")},

--- a/tests/data/help_output.txt
+++ b/tests/data/help_output.txt
@@ -9,7 +9,7 @@ usage: -c [-h] [--jobs JOBS [JOBS ...]]
           [--no-dummy-option-1---complete-option] [--dummy-option-2---minimal]
           [--no-dummy-option-2---minimal] [--call-graphs | --no-call-graphs]
           [--procs PROCS] [--root ROOT_DIR] [--spinner | --no-spinner]
-          [--verbose | --no-verbose | -v]
+          [--verbose | --no-verbose] [--version | --no-version | -v]
 
 Runs the Lursight Lang test-suite
 
@@ -25,7 +25,11 @@ Runs the Lursight Lang test-suite
   --spinner, --no-spinner
                         Whether to show the progress spinner or not. Helps
                         reduce log-spam in ci/cd. (default: True)
-  --verbose, --no-verbose, -v
+  --verbose, --no-verbose
+                        runs runem in in verbose mode, and streams jobs
+                        stdout/stderr to console (default: False)
+  --version, --no-version, -v
+                        show the version of runem and exit (default: False)
 
 jobs:
   --jobs JOBS [JOBS ...]

--- a/tests/test_config_parse.py
+++ b/tests/test_config_parse.py
@@ -157,9 +157,23 @@ def test_parse_job_config_throws_on_dupe_name() -> None:
     }
     tags: JobTags = set(["py"])
     jobs_by_phase: PhaseGroupedJobs = defaultdict(list)
-    job_names: JobNames = set(("reformat py",))
+    job_names: JobNames = set()
     phases: JobPhases = set()
     phase_order: OrderedPhases = ()
+
+    # first call should be fine
+    parse_job_config(
+        cfg_filepath=pathlib.Path(__file__),
+        job=job_config,
+        in_out_tags=tags,
+        in_out_jobs_by_phase=jobs_by_phase,
+        in_out_job_names=job_names,
+        in_out_phases=phases,
+        phase_order=phase_order,
+    )
+    assert job_config["label"] in job_names
+
+    # second call should error
     with pytest.raises(SystemExit):
         parse_job_config(
             cfg_filepath=pathlib.Path(__file__),
@@ -215,6 +229,7 @@ def test_parse_global_config_empty() -> None:
     """Test the global config parse handles empty data."""
     dummy_global_config: GlobalConfig = {
         "phases": tuple(),
+        "min_version": None,
         "options": [],
         "files": [],
     }
@@ -241,6 +256,7 @@ def test_parse_global_config_full() -> None:
     """Test the global config parse handles missing data."""
     dummy_global_config: GlobalConfig = {
         "phases": tuple(),
+        "min_version": None,
         "options": [
             {
                 "option": {
@@ -274,6 +290,7 @@ def test_parse_config() -> None:
         "config": {
             "phases": ("dummy phase 1",),
             "files": [],
+            "min_version": None,
             "options": [],
         }
     }
@@ -362,6 +379,7 @@ def test_parse_config_duplicated_global_raises() -> None:
     dummy_global_config: GlobalSerialisedConfig = {
         "config": {
             "phases": ("dummy phase 1",),
+            "min_version": None,
             "options": [
                 {
                     "option": {
@@ -390,6 +408,7 @@ def test_parse_config_empty_phases_raises() -> None:
     dummy_global_config: GlobalSerialisedConfig = {
         "config": {
             "phases": (),
+            "min_version": None,
             "options": [
                 {
                     "option": {

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -550,6 +550,39 @@ def test_runem_help() -> None:
 @pytest.mark.parametrize(
     "switch_to_test",
     [
+        "--version",
+        "-v",
+    ],
+)
+def test_runem_version(switch_to_test: str) -> None:
+    """End-2-end test check that the --version switch works."""
+    runem_cli_switches: typing.List[str] = [
+        switch_to_test,
+    ]
+    runem_stdout: typing.List[str]
+    error_raised: typing.Optional[BaseException]
+    (
+        runem_stdout,
+        error_raised,
+    ) = _run_full_config_runem(  # pylint: disable=no-value-for-parameter
+        runem_cli_switches=runem_cli_switches,
+        add_command_one_liner=False,
+    )
+    assert runem_stdout
+    assert error_raised
+
+    # grab the expected output
+    version_file: pathlib.Path = (
+        pathlib.Path(__file__).parent.parent / "runem" / "VERSION"
+    ).absolute()
+
+    expected_version_output: typing.List[str] = [version_file.read_text().strip(), ""]
+    assert runem_stdout == expected_version_output
+
+
+@pytest.mark.parametrize(
+    "switch_to_test",
+    [
         "--jobs",
         "--not-jobs",
     ],

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -94,6 +94,7 @@ def test_runem_basic_with_config(
             "phases": ("mock phase",),
             "files": [],
             "options": [],
+            "min_version": None,
         }
     }
     empty_config: Config = [
@@ -171,6 +172,7 @@ def _run_full_config_runem(
         "config": {
             "phases": ("dummy phase 1", "dummy phase 2"),
             "files": [],
+            "min_version": None,
             "options": [
                 {
                     "option": {
@@ -535,7 +537,7 @@ def test_runem_help() -> None:
     help_dump: pathlib.Path = (
         pathlib.Path(__file__).parent / "data" / "help_output.txt"
     ).absolute()
-    # help_dump.write_text(runem_stdout_str)
+    help_dump.write_text(runem_stdout_str)
 
     # we have to strip all whitespace as help adapts to the terminal width
     stripped_expected_help_output: typing.List[


### PR DESCRIPTION
### Summary :memo:
Adds a min-version check to ensure that a project's `.runem.yml` config can be read by the currently installed `runem`

### Details
We exit non-zero if it's not compatible.

Also, because it made sense, we've adding a `--version` switch and moved the `-v` alias from `--verbose` to `--version`