### PR TITLE
fix(stdout-parsing): ensures that trailing newlines are handled

### DIFF
--- a/runem/run_command.py
+++ b/runem/run_command.py
@@ -19,9 +19,29 @@ class RunCommandUnhandledError(RuntimeError):
 
 
 def parse_stdout(stdout: str, prefix: str) -> str:
-    """Prefixes each line of the output with a label."""
-    stdout = prefix + stdout.replace("\n", f"\n{prefix}")
-    return stdout
+    """Prefixes each line of the output with a given label, except trailing new
+    lines."""
+    # Edge case: Return the prefix immediately for an empty string
+    if not stdout:
+        return prefix
+
+    # Split stdout into lines, noting if it ends with a newline
+    ends_with_newline = stdout.endswith("\n")
+    lines = stdout.split("\n")
+
+    # Apply prefix to all lines except the last if it's empty (due to a trailing newline)
+    modified_lines = [f"{prefix}{line}" for line in lines[:-1]] + (
+        [lines[-1]]
+        if lines[-1] == "" and ends_with_newline
+        else [f"{prefix}{lines[-1]}"]
+    )
+
+    # Join the lines back together, appropriately handling the final newline
+    modified_stdout = "\n".join(modified_lines)
+    # if ends_with_newline:
+    #     modified_stdout += "\n"
+
+    return modified_stdout
 
 
 def _prepare_environment(
@@ -111,7 +131,7 @@ def run_command(  # noqa: C901
             for line in process.stdout:
                 stdout += line
                 if verbose:
-                    # print each line of output
+                    # print each line of output, assuming that each has a newline
                     log(parse_stdout(line, prefix=f"{label}: "))
 
             # Wait for the subprocess to finish and get the exit code

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -37,11 +37,33 @@ class MockPopen:
         return self.returncode
 
 
-def test_parse_stdout() -> None:
-    """Tests that parse_stdout returns a non bytes string."""
-    assert "test: test string" == runem.run_command.parse_stdout(
-        "test string", "test: "
-    )
+@pytest.mark.parametrize(
+    "stdout, expected",
+    [
+        ("Line1\nLine2", "Prefix: Line1\nPrefix: Line2"),
+        ("SingleLine", "Prefix: SingleLine"),
+        ("Line1\nLine2\n", "Prefix: Line1\nPrefix: Line2\n"),
+        ("\n", "Prefix: \n"),
+        ("", "Prefix: "),
+        ("Line1\n\nLine3", "Prefix: Line1\nPrefix: \nPrefix: Line3"),
+        ("Line1\nLine2\n\n", "Prefix: Line1\nPrefix: Line2\nPrefix: \n"),
+    ],
+    ids=[
+        "multiple_lines",
+        "single_line",
+        "multiple_lines_with_trailing_newline",
+        "single_newline",
+        "empty_string",
+        "lines_with_empty_line_in_between",
+        "multiple_lines_with_multiple_trailing_newlines",
+    ],
+)
+def test_parse_stdout(stdout: str, expected: str) -> None:
+    """Test various scenarios for the parse_stdout function.
+
+    NOTE: we assume non-bytes strings here.
+    """
+    assert runem.run_command.parse_stdout(stdout, "Prefix: ") == expected
 
 
 @patch("runem.run_command.Popen", autospec=True, return_value=MockPopen())


### PR DESCRIPTION
### Summary :memo:
There will be a slight performance cost to this, hopefully not too much.

### Details
We were getting several newlines logged out in `verbose` mode, sometimes with spurious 'prefix' logging in it. This fixes that.

However, we should probably move to a better logging system like python's inbuilt one.