### PR TITLE
Fix/aliases not setting options

### DIFF
--- a/runem/cli/initialise_options.py
+++ b/runem/cli/initialise_options.py
@@ -1,6 +1,7 @@
 import argparse
 
 from runem.config_metadata import ConfigMetadata
+from runem.informative_dict import InformativeDict
 from runem.types import Options
 
 
@@ -13,9 +14,9 @@ def initialise_options(
     Returns the options dictionary
     """
 
-    options: Options = {
-        option["name"]: option["default"] for option in config_metadata.options_config
-    }
+    options: Options = InformativeDict(
+        {option["name"]: option["default"] for option in config_metadata.options_config}
+    )
     if config_metadata.options_config and args.overrides_on:  # pragma: no branch
         for option_name in args.overrides_on:  # pragma: no branch
             options[option_name] = True

--- a/runem/cli/initialise_options.py
+++ b/runem/cli/initialise_options.py
@@ -2,19 +2,19 @@ import argparse
 
 from runem.config_metadata import ConfigMetadata
 from runem.informative_dict import InformativeDict
-from runem.types import Options
+from runem.types import OptionsWritable
 
 
 def initialise_options(
     config_metadata: ConfigMetadata,
     args: argparse.Namespace,
-) -> Options:
+) -> OptionsWritable:
     """Initialises and returns the set of options to use for this run.
 
     Returns the options dictionary
     """
 
-    options: Options = InformativeDict(
+    options: OptionsWritable = InformativeDict(
         {option["name"]: option["default"] for option in config_metadata.options_config}
     )
     if config_metadata.options_config and args.overrides_on:  # pragma: no branch

--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -5,6 +5,7 @@ import sys
 import typing
 
 from runem.config_metadata import ConfigMetadata
+from runem.informative_dict import InformativeDict
 from runem.log import log
 from runem.runem_version import get_runem_version
 from runem.types import JobNames, OptionConfig, Options
@@ -251,9 +252,9 @@ def initialise_options(
     Returns the options dictionary
     """
 
-    options: Options = {
-        option["name"]: option["default"] for option in config_metadata.options_config
-    }
+    options: Options = InformativeDict(
+        {option["name"]: option["default"] for option in config_metadata.options_config}
+    )
     if config_metadata.options_config and args.overrides_on:  # pragma: no branch
         for option_name in args.overrides_on:  # pragma: no branch
             options[option_name] = True

--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -8,7 +8,7 @@ from runem.config_metadata import ConfigMetadata
 from runem.informative_dict import InformativeDict
 from runem.log import log
 from runem.runem_version import get_runem_version
-from runem.types import JobNames, OptionConfig, Options
+from runem.types import JobNames, OptionConfig, OptionsWritable
 from runem.utils import printable_set
 
 
@@ -176,7 +176,7 @@ def parse_args(
         # cleanly exit
         sys.exit(0)
 
-    options: Options = initialise_options(config_metadata, args)
+    options: OptionsWritable = initialise_options(config_metadata, args)
 
     if not _validate_filters(config_metadata, args):
         sys.exit(1)
@@ -246,13 +246,13 @@ def _validate_filters(
 def initialise_options(
     config_metadata: ConfigMetadata,
     args: argparse.Namespace,
-) -> Options:
+) -> OptionsWritable:
     """Initialises and returns the set of options to use for this run.
 
     Returns the options dictionary
     """
 
-    options: Options = InformativeDict(
+    options: OptionsWritable = InformativeDict(
         {option["name"]: option["default"] for option in config_metadata.options_config}
     )
     if config_metadata.options_config and args.overrides_on:  # pragma: no branch

--- a/runem/config_metadata.py
+++ b/runem/config_metadata.py
@@ -1,6 +1,7 @@
 import argparse
 import pathlib
 
+from runem.informative_dict import InformativeDict
 from runem.types import (
     JobNames,
     JobPhases,
@@ -52,7 +53,7 @@ class ConfigMetadata:
         self.all_job_phases = all_job_phases
         self.all_job_tags = all_job_tags
 
-        self.options = {}  # will be defined after cli argument parsing
+        self.options = InformativeDict()  # shows useful errors on bad-option lookups
 
         self.args = (
             argparse.Namespace()

--- a/runem/config_metadata.py
+++ b/runem/config_metadata.py
@@ -7,7 +7,7 @@ from runem.types import (
     JobPhases,
     JobTags,
     OptionConfigs,
-    Options,
+    OptionsWritable,
     OrderedPhases,
     PhaseGroupedJobs,
     TagFileFilters,
@@ -25,7 +25,7 @@ class ConfigMetadata:
     all_job_phases: JobPhases  # the set of job-phases (should be subset of 'phases')
     all_job_tags: JobTags  # the set of job-tags (used for filtering)
 
-    options: Options  # the final configured options to pass to jobs
+    options: OptionsWritable  # the final configured options to pass to jobs
 
     args: argparse.Namespace  # the raw cli args, probably missing information
     jobs_to_run: JobNames  # superset of job-name candidates to run, from cli+config
@@ -70,7 +70,7 @@ class ConfigMetadata:
         phases_to_run: JobPhases,
         tags_to_run: JobTags,
         tags_to_avoid: JobTags,
-        options: Options,
+        options: OptionsWritable,
     ) -> None:
         self.options = options
         self.args = args

--- a/runem/informative_dict.py
+++ b/runem/informative_dict.py
@@ -1,0 +1,20 @@
+import typing
+
+# Define type variables for key and value to be used in the custom dictionary
+K = typing.TypeVar("K")
+V = typing.TypeVar("V")
+
+
+class InformativeDict(typing.Dict[K, V], typing.Generic[K, V]):
+    """A dictionary type that prints out the available keys."""
+
+    def __getitem__(self, key: K) -> V:
+        """Attempt to retrieve an item, raising a detailed exception if the key is not
+        found."""
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            available_keys: typing.Iterable[str] = (str(k) for k in self.keys())
+            raise KeyError(
+                f"Key '{key}' not found. Available keys: {', '.join(available_keys)}"
+            ) from None

--- a/runem/informative_dict.py
+++ b/runem/informative_dict.py
@@ -18,3 +18,25 @@ class InformativeDict(typing.Dict[K, V], typing.Generic[K, V]):
             raise KeyError(
                 f"Key '{key}' not found. Available keys: {', '.join(available_keys)}"
             ) from None
+
+
+class ReadOnlyInformativeDict(InformativeDict[K, V], typing.Generic[K, V]):
+    """A read-only variant of the above."""
+
+    def __setitem__(self, key: K, value: V) -> None:
+        raise NotImplementedError("This dictionary is read-only")
+
+    def __delitem__(self, key: K) -> None:
+        raise NotImplementedError("This dictionary is read-only")
+
+    def pop(self, *args: typing.Any, **kwargs: typing.Any) -> V:
+        raise NotImplementedError("This dictionary is read-only")
+
+    def popitem(self) -> typing.Tuple[K, V]:
+        raise NotImplementedError("This dictionary is read-only")
+
+    def clear(self) -> None:
+        raise NotImplementedError("This dictionary is read-only")
+
+    def update(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        raise NotImplementedError("This dictionary is read-only")

--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from timeit import default_timer as timer
 
 from runem.config_metadata import ConfigMetadata
+from runem.informative_dict import ReadOnlyInformativeDict
 from runem.job import Job
 from runem.job_wrapper import get_job_wrapper
 from runem.log import log
@@ -62,7 +63,7 @@ def job_execute_inner(
             )
         else:
             reports = function(
-                options=config_metadata.options,  # type: ignore
+                options=ReadOnlyInformativeDict(config_metadata.options),  # type: ignore
                 file_list=file_list,
                 procs=config_metadata.args.procs,
                 root_path=root_path,

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -334,9 +334,12 @@ def timed_main(argv: typing.List[str]) -> None:
     end = timer()
     time_taken: timedelta = timedelta(seconds=end - start)
     time_saved = report_on_run(phase_run_oder, job_run_metadatas, time_taken)
+    message: str = "DONE: runem took"
+    if failure_exception:
+        message = "FAILED: your jobs failed after"
     log(
         (
-            f"DONE: runem took: {time_taken.total_seconds()}s, "
+            f"{message}: {time_taken.total_seconds()}s, "
             f"saving you {time_saved.total_seconds()}s"
         )
     )

--- a/runem/types.py
+++ b/runem/types.py
@@ -55,8 +55,9 @@ OptionName = str
 OptionValue = bool
 
 OptionConfigs = typing.Tuple[OptionConfig, ...]
-Options = InformativeDict[OptionName, OptionValue]
+OptionsWritable = InformativeDict[OptionName, OptionValue]
 OptionsReadOnly = ReadOnlyInformativeDict[OptionName, OptionValue]
+Options = OptionsReadOnly
 
 # P1: bool for verbose, P2: list of file paths to work on
 
@@ -73,7 +74,7 @@ FilePathListLookup = typing.DefaultDict[JobTag, FilePathList]
 
 # FIXME: this type is no-longer the actual spec of the test-functions
 JobFunction = typing.Union[
-    typing.Callable[[argparse.Namespace, Options, FilePathList], None],
+    typing.Callable[[argparse.Namespace, OptionsWritable, FilePathList], None],
     typing.Callable[[typing.Any], None],
 ]
 

--- a/runem/types.py
+++ b/runem/types.py
@@ -3,6 +3,8 @@ import pathlib
 import typing
 from datetime import timedelta
 
+from runem.informative_dict import InformativeDict
+
 
 class FunctionNotFound(ValueError):
     """Thrown when the test-function cannot be found."""
@@ -53,7 +55,7 @@ OptionName = str
 OptionValue = bool
 
 OptionConfigs = typing.Tuple[OptionConfig, ...]
-Options = typing.Dict[OptionName, OptionValue]
+Options = InformativeDict[OptionName, OptionValue]
 
 # P1: bool for verbose, P2: list of file paths to work on
 

--- a/runem/types.py
+++ b/runem/types.py
@@ -3,7 +3,7 @@ import pathlib
 import typing
 from datetime import timedelta
 
-from runem.informative_dict import InformativeDict
+from runem.informative_dict import InformativeDict, ReadOnlyInformativeDict
 
 
 class FunctionNotFound(ValueError):
@@ -56,6 +56,7 @@ OptionValue = bool
 
 OptionConfigs = typing.Tuple[OptionConfig, ...]
 Options = InformativeDict[OptionName, OptionValue]
+OptionsReadOnly = ReadOnlyInformativeDict[OptionName, OptionValue]
 
 # P1: bool for verbose, P2: list of file paths to work on
 

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -4,7 +4,7 @@ import typing
 
 from runem.log import log
 from runem.run_command import RunCommandUnhandledError, run_command
-from runem.types import FilePathList, JobName, JobReturnData, Options
+from runem.types import FilePathList, JobName, JobReturnData, OptionsWritable
 
 
 def _job_py_code_reformat(
@@ -12,7 +12,7 @@ def _job_py_code_reformat(
 ) -> None:
     """Runs python formatting code in serial order as one influences the other."""
     label: JobName = kwargs["label"]
-    options: Options = kwargs["options"]
+    options: OptionsWritable = kwargs["options"]
     python_files: FilePathList = kwargs["file_list"]
 
     # put into 'check' mode if requested on the command line
@@ -132,7 +132,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
     **kwargs: typing.Any,
 ) -> JobReturnData:
     label: JobName = kwargs["label"]
-    options: Options = kwargs["options"]
+    options: OptionsWritable = kwargs["options"]
     procs: int = kwargs["procs"]
     root_path: pathlib.Path = kwargs["root_path"]
 
@@ -261,7 +261,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
 def _install_python_requirements(
     **kwargs: typing.Any,
 ) -> None:
-    options: Options = kwargs["options"]
+    options: OptionsWritable = kwargs["options"]
     root_path: pathlib.Path = kwargs["root_path"]
     if not ("install deps" in options and options["install deps"]):
         # not enabled

--- a/scripts/test_hooks/yarn.py
+++ b/scripts/test_hooks/yarn.py
@@ -1,7 +1,7 @@
 import typing
 
 from runem.run_command import run_command
-from runem.types import Options
+from runem.types import OptionsWritable
 
 
 def _job_prettier(
@@ -11,7 +11,7 @@ def _job_prettier(
 
     TODO: connect me up!
     """
-    options: Options = kwargs["options"]
+    options: OptionsWritable = kwargs["options"]
     command_variant = "pretty"
     if "check_only" in options and options["check_only"]:
         command_variant = "prettyCheck"

--- a/tests/test_informative_dict.py
+++ b/tests/test_informative_dict.py
@@ -1,0 +1,39 @@
+import pytest
+
+from runem.informative_dict import InformativeDict
+
+
+@pytest.fixture(name="sample_dict")
+def sample_dict_fixture() -> InformativeDict[str, int]:
+    """Test fixture for creating an instance of InformativeDict."""
+    return InformativeDict({"one": 1, "two": 2, "three": 3})
+
+
+def test_getitem_existing_key(sample_dict: InformativeDict[str, int]) -> None:
+    assert (
+        sample_dict["one"] == 1
+    ), "Should retrieve the correct value for an existing key"
+
+
+def test_getitem_non_existent_key(sample_dict: InformativeDict[str, int]) -> None:
+    with pytest.raises(KeyError) as exc_info:
+        _ = sample_dict["four"]
+    assert "Key 'four' not found. Available keys: one, two, three" in str(
+        exc_info.value
+    ), "Should raise KeyError with a message listing available keys"
+
+
+def test_iteration(sample_dict: InformativeDict[str, int]) -> None:
+    keys = list(sample_dict)
+    assert keys == [
+        "one",
+        "two",
+        "three",
+    ], "Iteration over dictionary should yield all keys"
+
+
+def test_initialization_with_items() -> None:
+    dict_init = InformativeDict({"a": 1, "b": 2})
+    assert (
+        dict_init["a"] == 1 and dict_init["b"] == 2
+    ), "Should correctly initialize with given items"

--- a/tests/test_job_execute.py
+++ b/tests/test_job_execute.py
@@ -180,9 +180,9 @@ def test_job_execute_basic_call_verbose() -> None:
         file_lists,
     )
     assert stdout == (
-        "runem: START: reformat py\n"
-        "runem: job: running reformat py\n"
-        "runem: DONE: reformat py: 0:00:00\n"
+        "runem: START: 'reformat py'\n"
+        "runem: job: running: 'reformat py'\n"
+        "runem: job: DONE: 'reformat py': 0:00:00\n"
     )
 
 
@@ -242,10 +242,10 @@ def test_job_execute_empty_files() -> None:
         file_lists,
     )
     assert stdout == (
-        "runem: START: reformat py\n"
+        "runem: START: 'reformat py'\n"
         "runem: WARNING: skipping job 'reformat py', no files for job\n"
-        # "runem: job: running reformat py\n"
-        # "runem: DONE: reformat py: 0:00:00\n"
+        # "runem: job: running: 'reformat py'\n"
+        # "runem: job: DONE: 'reformat py': 0:00:00\n"
     )
 
 
@@ -309,9 +309,9 @@ def test_job_execute_with_ctx_cwd() -> None:
         file_lists,
     )
     assert stdout == (
-        "runem: START: reformat py\n"
-        "runem: job: running reformat py\n"
-        "runem: DONE: reformat py: 0:00:00\n"
+        "runem: START: 'reformat py'\n"
+        "runem: job: running: 'reformat py'\n"
+        "runem: job: DONE: 'reformat py': 0:00:00\n"
     )
 
 
@@ -375,9 +375,9 @@ def test_job_execute_with_old_style_func() -> None:
         file_lists,
     )
     assert stdout == (
-        "runem: START: reformat py\n"
-        "runem: job: running reformat py\n"
-        "runem: DONE: reformat py: 0:00:00\n"
+        "runem: START: 'reformat py'\n"
+        "runem: job: running: 'reformat py'\n"
+        "runem: job: DONE: 'reformat py': 0:00:00\n"
     )
 
 
@@ -451,7 +451,10 @@ def test_job_execute_with_raising_func() -> None:
         file_lists,
     )
     assert isinstance(err, IntentionalTestError)
-    assert stdout == (
-        "runem: START: intentionally throwing\n"
-        "runem: job: running intentionally throwing\n"
-    )
+    assert stdout.split("\n") == [
+        "runem: START: 'intentionally throwing'",
+        "runem: job: running: 'intentionally throwing'",
+        "",
+        "runem: job: ERROR: job 'intentionally throwing' failed to complete!",
+        "",
+    ]

--- a/tests/test_job_execute.py
+++ b/tests/test_job_execute.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from runem.config_metadata import ConfigMetadata
+from runem.informative_dict import InformativeDict
 from runem.job_execute import job_execute
 from runem.types import (
     FilePathList,
@@ -110,7 +111,7 @@ def test_job_execute_basic_call() -> None:
         phases_to_run=set(),  # ignored JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
 
     file_lists: FilePathListLookup = defaultdict(list)
@@ -168,7 +169,7 @@ def test_job_execute_basic_call_verbose() -> None:
         phases_to_run=set(),  # ignored JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
 
     file_lists: FilePathListLookup = defaultdict(list)
@@ -230,7 +231,7 @@ def test_job_execute_empty_files() -> None:
         phases_to_run=set(),  # ignored JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
 
     file_lists: FilePathListLookup = defaultdict(list)
@@ -297,7 +298,7 @@ def test_job_execute_with_ctx_cwd() -> None:
         phases_to_run=set(),  # ignored JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
 
     file_lists: FilePathListLookup = defaultdict(list)
@@ -363,7 +364,7 @@ def test_job_execute_with_old_style_func() -> None:
         phases_to_run=set(),  # ignored JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
 
     file_lists: FilePathListLookup = defaultdict(list)
@@ -438,7 +439,7 @@ def test_job_execute_with_raising_func() -> None:
         phases_to_run=set(),  # ignored JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
 
     file_lists: FilePathListLookup = defaultdict(list)

--- a/tests/test_job_execute.py
+++ b/tests/test_job_execute.py
@@ -15,7 +15,7 @@ from runem.types import (
     FilePathList,
     FilePathListLookup,
     JobConfig,
-    Options,
+    OptionsWritable,
     PhaseGroupedJobs,
 )
 from tests.intentional_test_error import IntentionalTestError
@@ -31,7 +31,7 @@ def intentionally_raising_function(**kwargs: typing.Any) -> None:
 
 
 def old_style_function(
-    args: Namespace, options: Options, file_list: FilePathList
+    args: Namespace, options: OptionsWritable, file_list: FilePathList
 ) -> None:
     """Does nothing called by runner."""
 

--- a/tests/test_job_filter.py
+++ b/tests/test_job_filter.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from runem.config_metadata import ConfigMetadata
+from runem.informative_dict import InformativeDict
 from runem.job_filter import _get_jobs_matching, _should_filter_out_by_tags, filter_jobs
 from runem.types import JobConfig, JobTags, PhaseGroupedJobs
 
@@ -60,7 +61,7 @@ def test_runem_job_filters_work_with_no_tags(verbosity: bool) -> None:
         phases_to_run=set(),  # ignored JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
     with io.StringIO() as buf, redirect_stdout(buf):
         filter_jobs(config_metadata)

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from runem.config_metadata import ConfigMetadata
+from runem.informative_dict import InformativeDict
 from runem.runem import (
     _process_jobs,
     _process_jobs_by_phase,
@@ -1377,7 +1378,7 @@ def test_process_jobs_by_phase_early_exits_with_exceptions(
         phases_to_run=set(all_phase_names),  # JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
 
     file_lists: FilePathListLookup = defaultdict(list)
@@ -1489,7 +1490,7 @@ def test_process_jobs_early_exits_with_exceptions(
         phases_to_run=set(all_phase_names),  # JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options={},  # Options,
+        options=InformativeDict({}),  # Options,
     )
 
     file_lists: FilePathListLookup = defaultdict(list)


### PR DESCRIPTION
### Summary :memo:

Make the options access much more clear, from a user's perspective.

### Details

Options are now read-only and print the available keys if an option is looked-for but not found.

This makes user's code a bit simpler and easier to manage. It also makes mistakes easier to spot for users and gives hints on how to resolve them.