### PR TITLE
Feat/prettier tree graph

### DIFF
--- a/runem/report.py
+++ b/runem/report.py
@@ -103,8 +103,8 @@ def _plot_times(
 
     for idx, phase in enumerate(phase_run_oder):
         not_last_phase: bool = idx < len(phase_run_oder) - 1
-        utf8_phase = "├" if not_last_phase else "└"
-        utf8_phase_group = "│" if not_last_phase else " "
+        utf8_phase = " ├" if not_last_phase else " └"
+        utf8_phase_group = " │" if not_last_phase else "  "
         # log(f"Phase '{phase}' jobs took:")
         phase_start_idx = len(labels)
 
@@ -121,9 +121,11 @@ def _plot_times(
 
     runem_app_timing: typing.List[JobTiming] = timing_data["_app"]
     job_metadata: JobTiming
-    for job_metadata in reversed(runem_app_timing):
+    for idx, job_metadata in enumerate(reversed(runem_app_timing)):
+        last_group: bool = idx == 0  # revere sorted
+        utf8_group = "├" if not last_group else "└"
         job_label, job_time_total = job_metadata["job"]
-        labels.insert(0, f"├runem.{job_label}")
+        labels.insert(0, f"{utf8_group}runem.{job_label}")
         times.insert(0, job_time_total.total_seconds())
     labels.insert(0, "runem (total wall-clock)")
     times.insert(0, wall_clock_for_runem_main.total_seconds())

--- a/runem/report.py
+++ b/runem/report.py
@@ -43,7 +43,7 @@ def _align_bar_graphs_workaround(original_text: str) -> str:
     return formatted_text
 
 
-def _replace_bar_characters(text: str, end_str: str, replace_char: str) -> str:
+def replace_bar_graph_characters(text: str, end_str: str, replace_char: str) -> str:
     """Replaces block characters in lines containing `end_str` with give char.
 
     Args:
@@ -56,7 +56,7 @@ def _replace_bar_characters(text: str, end_str: str, replace_char: str) -> str:
     """
     # Define the block character and its light shade replacement
     block_chars = (
-        "▏▎▋▊█▌▐▄▀─"  # Extend this string with any additional block characters you use
+        "▏▎▍▋▊█▌▐▄▀─"  # Extend this string with any additional block characters you use
     )
 
     text_lines: typing.List[str] = text.split("\n")
@@ -74,12 +74,12 @@ def _replace_bar_characters(text: str, end_str: str, replace_char: str) -> str:
 
 def _semi_shade_phase_totals(text: str) -> str:
     light_shade_char = "░"
-    return _replace_bar_characters(text, "(user-time)", light_shade_char)
+    return replace_bar_graph_characters(text, "(user-time)", light_shade_char)
 
 
 def _dot_jobs(text: str) -> str:
     dot_char = "·"
-    return _replace_bar_characters(text, "(+)", dot_char)
+    return replace_bar_graph_characters(text, "(+)", dot_char)
 
 
 def _plot_times(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -67,16 +67,16 @@ def test_report_on_run_basic_call() -> None:
         run_command_stdout = buf.getvalue()
     assert run_command_stdout.split("\n") == [
         "runem: reports:",
-        "runem (total wall-clock)         [1000.500000]  ████████████████████████████████",
+        "runem (total wall-clock)          [1000.500000]  ████████████████████████████████",
         (
-            "└phase 1 (user-time)             [1252.001001] "
+            " └phase 1 (user-time)             [1252.001001] "
             " ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"
         ),
-        " ├phase 1.job label 2            [1000.001001]  ████████████████████████████████",
-        " │├phase 1.job label 2.sub1 (+)  [ 500.000000]  ················",
-        " │└phase 1.job label 2.sub2 (+)  [ 500.000000]  ················",
-        " ├phase 1.another job 3          [   2.000000]  ▏",
-        " └phase 1.another job 4          [ 250.000000]  ████████",
+        "  ├phase 1.job label 2            [1000.001001]  ████████████████████████████████",
+        "  │├phase 1.job label 2.sub1 (+)  [ 500.000000]  ················",
+        "  │└phase 1.job label 2.sub2 (+)  [ 500.000000]  ················",
+        "  ├phase 1.another job 3          [   2.000000]  ▏",
+        "  └phase 1.another job 4          [ 250.000000]  ████████",
         "",
     ]
     # this floating-point comparison should be problematic but its' working for
@@ -130,9 +130,9 @@ def test_report_on_run_reports() -> None:
     assert run_command_stdout.split("\n") == [
         "runem: reports:",
         "runem (total wall-clock)  [   0.000000]",
-        "└phase 1 (user-time)      [1002.001001]  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░",
-        " ├phase 1.job label 2     [1000.001001]  ███████████████████████████████████████▉",
-        " └phase 1.another job 3   [   2.000000]  ▏",
+        " └phase 1 (user-time)     [1002.001001]  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░",
+        "  ├phase 1.job label 2    [1000.001001]  ███████████████████████████████████████▉",
+        "  └phase 1.another job 3  [   2.000000]  ▏",
         "runem: report: dummy report label: /dummy/report/url",
         "",
     ]

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -135,8 +135,8 @@ def test_runem_basic_with_config(
             "runem: reports:",
             "runem (total wall-clock)  [<float>]  ",
             "├runem.pre-build          [<float>]  ",
-            "├runem.run-phases         [<float>]  ",
-            "└mock phase (user-time)   [<float>]",
+            "└runem.run-phases         [<float>]  ",
+            " └mock phase (user-time)  [<float>]",
             "runem: DONE: runem took: <float>, saving you <float>, without runem you "
             "would have waited <float>",
             "",
@@ -175,8 +175,8 @@ def test_runem_basic_with_config_no_options(
             "runem: reports:",
             "runem (total wall-clock)  [<float>]  ",
             "├runem.pre-build          [<float>]  ",
-            "├runem.run-phases         [<float>]  ",
-            "└mock phase (user-time)   [<float>]",
+            "└runem.run-phases         [<float>]  ",
+            " └mock phase (user-time)  [<float>]",
             "runem: DONE: runem took: <float>, saving you <float>, without runem you "
             "would have waited <float>",
             "",

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -18,6 +18,7 @@ import pytest
 
 from runem.config_metadata import ConfigMetadata
 from runem.informative_dict import InformativeDict
+from runem.report import replace_bar_graph_characters
 from runem.runem import (
     _process_jobs,
     _process_jobs_by_phase,
@@ -71,6 +72,22 @@ def _strip_reports_footer(runem_stdout: typing.List[str]) -> typing.List[str]:
     return runem_stdout[:idx]
 
 
+def _sanitise_reports_footer(stdout: str) -> typing.List[str]:
+    """Strips variable content like floats and bar-graphs from the std out."""
+    special_char: str = "="
+    bar_less_stdout: str = replace_bar_graph_characters(
+        stdout,
+        end_str=" ",  # strip all lines
+        replace_char=special_char,  # use a char that isn't used elsewise
+    ).replace(special_char, "")
+
+    lines: typing.List[str] = bar_less_stdout.split("\n")
+    stripped_of_floats: typing.List[str] = [
+        re.sub(r"-?\b\d+\.\d+s?\b", "<float>", text) for text in lines
+    ]
+    return stripped_of_floats
+
+
 def test_runem_basic() -> None:
     """Tests new user's first call-path, when they wouldn't have a .runem.yml."""
     with io.StringIO() as buf, redirect_stdout(buf):
@@ -111,8 +128,19 @@ def test_runem_basic_with_config(
     with io.StringIO() as buf, redirect_stdout(buf):
         # with pytest.raises(SystemExit):
         timed_main(["--help"])
-        runem_stdout = buf.getvalue().split("\n")
+        runem_stdout: typing.List[str] = _sanitise_reports_footer(buf.getvalue())
         assert [] == _strip_reports_footer(runem_stdout)
+
+        assert [
+            "runem: reports:",
+            "runem (total wall-clock)  [<float>]  ",
+            "├runem.pre-build          [<float>]  ",
+            "├runem.run-phases         [<float>]  ",
+            "└mock phase (user-time)   [<float>]",
+            "runem: DONE: runem took: <float>, saving you <float>, without runem you "
+            "would have waited <float>",
+            "",
+        ] == runem_stdout
 
 
 @patch(
@@ -142,8 +170,17 @@ def test_runem_basic_with_config_no_options(
     with io.StringIO() as buf, redirect_stdout(buf):
         # with pytest.raises(SystemExit):
         timed_main(["--help"])
-        runem_stdout = buf.getvalue().split("\n")
-        assert [] == _strip_reports_footer(runem_stdout)
+        runem_stdout = buf.getvalue()
+        assert [
+            "runem: reports:",
+            "runem (total wall-clock)  [<float>]  ",
+            "├runem.pre-build          [<float>]  ",
+            "├runem.run-phases         [<float>]  ",
+            "└mock phase (user-time)   [<float>]",
+            "runem: DONE: runem took: <float>, saving you <float>, without runem you "
+            "would have waited <float>",
+            "",
+        ] == _sanitise_reports_footer(runem_stdout)
 
 
 MOCK_JOB_EXECUTE_INNER_RET: typing.Tuple[JobTiming, JobReturn] = (


### PR DESCRIPTION
### Summary :memo:

Appropriately pins job-times in the reports section of runem.

### Details

Changes the indentation levels of the phases so that they are clearly part of the phase-running section of runem.

From:
```text
├runem.run-phases         [<float>s] <bar-graph>
└mock phase (user-time)  [<float>s] <bar-graph>
```

To:
```text
└runem.run-phases         [<float>s] <bar-graph>
 └mock phase (user-time)  [<float>s] <bar-graph>
```
