### PR TITLE
Feat/prettier tree graph

### DIFF
--- a/.runem.yml
+++ b/.runem.yml
@@ -51,25 +51,9 @@
           desc: generate profile information in jobs that can
           type: bool
       - option:
-          alias: u
-          default: true
-          desc: update snapshots in jobs that can update data snapshots
-          name: update snapshots
-          type: bool
-      - option:
           default: true
           desc: run unit tests
           name: unit test
-          type: bool
-      - option:
-          default: false
-          desc: run unit tests for the firebase function's data
-          name: unit test firebase data
-          type: bool
-      - option:
-          default: false
-          desc: run unit tests for the python code
-          name: unit test python
           type: bool
 - job:
     addr:

--- a/.runem.yml
+++ b/.runem.yml
@@ -22,7 +22,7 @@
       - option:
           alias: check
           default: false
-          name: check_only
+          name: check-only
           type: bool
           desc: runs in check-mode, erroring if isort, black or any text-edits would occur
       - option:
@@ -37,7 +37,7 @@
           type: bool
       - option:
           default: false
-          name: install deps
+          name: install-deps
           type: bool
           desc: gets dep-installing job to run
       - option:

--- a/.runem.yml
+++ b/.runem.yml
@@ -52,8 +52,8 @@
           type: bool
       - option:
           default: true
+          name: unit-test
           desc: run unit tests
-          name: unit test
           type: bool
 - job:
     addr:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Here's a simple setup for a python project.
           type: bool
           desc: formats docs and comments in whatever job can do so
       - option:
-          name: check_only
+          name: check-only
           alias: check
           default: false
           type: bool
@@ -213,7 +213,7 @@ def _job_py_code_reformat(
     docformatter_extra_args = [
         "--in-place",
     ]
-    if "check_only" in options and options["check_only"]:
+    if "check-only" in options and options["check-only"]:
         extra_args.append("--check")
         docformatter_extra_args = []  # --inplace is not compatible with --check
 
@@ -245,7 +245,7 @@ def _job_py_code_reformat(
             0,  # no work/change required
             3,  # no errors, but code was reformatted
         )
-        if "check_only" in options and options["check_only"]:
+        if "check-only" in options and options["check-only"]:
             # in check it is ONLY ok if no work/change was required
             allowed_exits = (0,)
         kwargs["label"] = f"{label} docformatter"

--- a/README.md
+++ b/README.md
@@ -213,11 +213,11 @@ def _job_py_code_reformat(
     docformatter_extra_args = [
         "--in-place",
     ]
-    if "check-only" in options and options["check-only"]:
+    if options["check-only"]:
         extra_args.append("--check")
         docformatter_extra_args = []  # --inplace is not compatible with --check
 
-    if "black" in options and options["black"]:
+    if options["black"]:
         black_cmd = [
             "python3",
             "-m",
@@ -228,7 +228,7 @@ def _job_py_code_reformat(
         kwargs["label"] = f"{label} black"
         run_command(cmd=black_cmd, **kwargs)
 
-    if "docformatter" in options and options["docformatter"]:
+    if options["docformatter"]:
         docformatter_cmd = [
             "python3",
             "-m",
@@ -245,7 +245,7 @@ def _job_py_code_reformat(
             0,  # no work/change required
             3,  # no errors, but code was reformatted
         )
-        if "check-only" in options and options["check-only"]:
+        if options["check-only"]:
             # in check it is ONLY ok if no work/change was required
             allowed_exits = (0,)
         kwargs["label"] = f"{label} docformatter"

--- a/README.md
+++ b/README.md
@@ -435,8 +435,8 @@ usage: runem.py [-h] [--jobs JOBS [JOBS ...]] [--not-jobs JOBS_EXCLUDED [JOBS_EX
                 [--not-phases PHASES_EXCLUDED [PHASES_EXCLUDED ...]] [--tags TAGS [TAGS ...]] [--not-tags TAGS_EXCLUDED [TAGS_EXCLUDED ...]]
                 [--black] [--no-black] [--check-only] [--no-check-only] [--coverage] [--no-coverage] [--docformatter] [--no-docformatter]
                 [--generate-call-graphs] [--no-generate-call-graphs] [--install-deps] [--no-install-deps] [--isort] [--no-isort] [--profile]
-                [--no-profile] [--update-snapshots] [--no-update-snapshots] [--unit-test] [--no-unit-test] [--unit-test-firebase-data]
-                [--no-unit-test-firebase-data] [--unit-test-python] [--no-unit-test-python] [--call-graphs | --no-call-graphs]
+                [--no-profile] [--unit-test] [--no-unit-test]
+                [--call-graphs | --no-call-graphs]
                 [--procs PROCS] [--root ROOT_DIR] [--verbose | --no-verbose | -v]
 
 Runs the Lursight Lang test-suite
@@ -490,18 +490,8 @@ job-param overrides:
   --no-isort            turn off allow/disallows isort from running on python files
   --profile             generate profile information in jobs that can
   --no-profile          turn off generate profile information in jobs that can
-  --update-snapshots    update snapshots in jobs that can update data snapshots
-  --no-update-snapshots
-                        turn off update snapshots in jobs that can update data snapshots
   --unit-test           run unit tests
   --no-unit-test        turn off run unit tests
-  --unit-test-firebase-data
-                        run unit tests for the firebase function's data
-  --no-unit-test-firebase-data
-                        turn off run unit tests for the firebase function's data
-  --unit-test-python    run unit tests for the python code
-  --no-unit-test-python
-                        turn off run unit tests for the python code
 ```
 </details>
 

--- a/runem/report.py
+++ b/runem/report.py
@@ -56,7 +56,8 @@ def replace_bar_graph_characters(text: str, end_str: str, replace_char: str) -> 
     """
     # Define the block character and its light shade replacement
     block_chars = (
-        "▏▎▍▋▊█▌▐▄▀─"  # Extend this string with any additional block characters you use
+        "▏▎▍▋▊▉█▌▐▄▀─"  # Extend this string with any additional block characters you use
+        "░·"  # also include the chars we might replace with for special bars
     )
 
     text_lines: typing.List[str] = text.split("\n")

--- a/runem/report.py
+++ b/runem/report.py
@@ -178,7 +178,7 @@ def _gen_jobs_report(
         utf8_job = "├" if not_last else "└"
         utf8_sub_jobs = "│" if not_last else " "
         job_label, job_time_total = job_timing["job"]
-        job_bar_label: str = f"{phase}.{job_label}"
+        job_bar_label: str = f"{job_label}"
         labels.append(f"{utf8_phase_group}{utf8_job}{job_bar_label}")
         times.append(job_time_total.total_seconds())
         job_time_sum += job_time_total
@@ -194,8 +194,7 @@ def _gen_jobs_report(
             if idx == len(sub_command_times) - 1:
                 sub_utf8 = "└"
             labels.append(
-                f"{utf8_phase_group}{utf8_sub_jobs}{sub_utf8}{job_bar_label}"
-                f".{sub_job_label} (+)"
+                f"{utf8_phase_group}{utf8_sub_jobs}{sub_utf8}{sub_job_label} (+)"
             )
             times.append(sub_job_time.total_seconds())
     return job_time_sum

--- a/runem/report.py
+++ b/runem/report.py
@@ -122,7 +122,7 @@ def _plot_times(
     runem_app_timing: typing.List[JobTiming] = timing_data["_app"]
     job_metadata: JobTiming
     for idx, job_metadata in enumerate(reversed(runem_app_timing)):
-        last_group: bool = idx == 0  # revere sorted
+        last_group: bool = idx == 0  # reverse sorted
         utf8_group = "├" if not last_group else "└"
         job_label, job_time_total = job_metadata["job"]
         labels.insert(0, f"{utf8_group}runem.{job_label}")

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -141,6 +141,10 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
     # pytest_cfg = root_path / ".pytest.ini"
     # assert pytest_cfg.exists()
 
+    if not options["unit-test"]:
+        # we've disabled unit-testing on the cli
+        return reports
+
     if "profile" in options and options["profile"]:
         raise RuntimeError("not implemented - see run_test.sh for how to implement")
 
@@ -186,7 +190,6 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
         str(pytest_path),
     ]
 
-    # use sqlite for unit-tests
     env_overrides: typing.Dict[str, str] = {}
 
     kwargs["label"] = f"{label} pytest"

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -20,11 +20,11 @@ def _job_py_code_reformat(
     docformatter_extra_args = [
         "--in-place",
     ]
-    if "check-only" in options and options["check-only"]:
+    if options["check-only"]:
         extra_args.append("--check")
         docformatter_extra_args = []  # --inplace is not compatible with --check
 
-    if "isort" in options and options["isort"]:
+    if options["isort"]:
         isort_cmd = [
             "python3",
             "-m",
@@ -38,7 +38,7 @@ def _job_py_code_reformat(
         kwargs["label"] = f"{label} isort"
         run_command(cmd=isort_cmd, **kwargs)
 
-    if "black" in options and options["black"]:
+    if options["black"]:
         black_cmd = [
             "python3",
             "-m",
@@ -49,7 +49,7 @@ def _job_py_code_reformat(
         kwargs["label"] = f"{label} black"
         run_command(cmd=black_cmd, **kwargs)
 
-    if "docformatter" in options and options["docformatter"]:
+    if options["docformatter"]:
         docformatter_cmd = [
             "python3",
             "-m",
@@ -66,7 +66,7 @@ def _job_py_code_reformat(
             0,  # no work/change required
             3,  # no errors, but code was reformatted
         )
-        if "check-only" in options and options["check-only"]:
+        if options["check-only"]:
             # in check it is ONLY ok if no work/change was required
             allowed_exits = (0,)
         kwargs["label"] = f"{label} docformatter"
@@ -145,7 +145,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
         # we've disabled unit-testing on the cli
         return reports
 
-    if "profile" in options and options["profile"]:
+    if options["profile"]:
         raise RuntimeError("not implemented - see run_test.sh for how to implement")
 
     pytest_path = root_path / "tests"
@@ -153,7 +153,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
 
     coverage_switches: typing.List[str] = []
     coverage_cfg = root_path / ".coveragerc"
-    if "coverage" in options and options["coverage"]:
+    if options["coverage"]:
         assert coverage_cfg.exists()
         coverage_switches = [
             "--cov=.",
@@ -199,7 +199,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
         **kwargs,
     )
 
-    if "coverage" in options and options["coverage"]:
+    if options["coverage"]:
         reports_dir: pathlib.Path = root_path / "reports"
         reports_dir.mkdir(parents=False, exist_ok=True)
         coverage_output_dir: pathlib.Path = reports_dir / "coverage_python"
@@ -266,7 +266,7 @@ def _install_python_requirements(
 ) -> None:
     options: OptionsWritable = kwargs["options"]
     root_path: pathlib.Path = kwargs["root_path"]
-    if not ("install-deps" in options and options["install-deps"]):
+    if not (options["install-deps"]):
         # not enabled
         return
     requirements_path = root_path

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -20,7 +20,7 @@ def _job_py_code_reformat(
     docformatter_extra_args = [
         "--in-place",
     ]
-    if "check_only" in options and options["check_only"]:
+    if "check-only" in options and options["check-only"]:
         extra_args.append("--check")
         docformatter_extra_args = []  # --inplace is not compatible with --check
 
@@ -66,7 +66,7 @@ def _job_py_code_reformat(
             0,  # no work/change required
             3,  # no errors, but code was reformatted
         )
-        if "check_only" in options and options["check_only"]:
+        if "check-only" in options and options["check-only"]:
             # in check it is ONLY ok if no work/change was required
             allowed_exits = (0,)
         kwargs["label"] = f"{label} docformatter"
@@ -263,7 +263,7 @@ def _install_python_requirements(
 ) -> None:
     options: OptionsWritable = kwargs["options"]
     root_path: pathlib.Path = kwargs["root_path"]
-    if not ("install deps" in options and options["install deps"]):
+    if not ("install-deps" in options and options["install-deps"]):
         # not enabled
         return
     requirements_path = root_path

--- a/scripts/test_hooks/yarn.py
+++ b/scripts/test_hooks/yarn.py
@@ -13,7 +13,7 @@ def _job_prettier(
     """
     options: OptionsWritable = kwargs["options"]
     command_variant = "pretty"
-    if "check-only" in options and options["check-only"]:
+    if options["check-only"]:
         command_variant = "prettyCheck"
 
     pretty_cmd = [

--- a/scripts/test_hooks/yarn.py
+++ b/scripts/test_hooks/yarn.py
@@ -13,7 +13,7 @@ def _job_prettier(
     """
     options: OptionsWritable = kwargs["options"]
     command_variant = "pretty"
-    if "check_only" in options and options["check_only"]:
+    if "check-only" in options and options["check-only"]:
         command_variant = "prettyCheck"
 
     pretty_cmd = [

--- a/tests/sanitise_reports_footer.py
+++ b/tests/sanitise_reports_footer.py
@@ -1,0 +1,20 @@
+import re
+import typing
+
+from runem.report import replace_bar_graph_characters
+
+
+def sanitise_reports_footer(stdout: str) -> typing.List[str]:
+    """Strips variable content like floats and bar-graphs from the std out."""
+    special_char: str = "="
+    bar_less_stdout: str = replace_bar_graph_characters(
+        stdout,
+        end_str=" ",  # strip all lines
+        replace_char=special_char,  # use a char that isn't used elsewise
+    ).replace(special_char, "")
+
+    lines: typing.List[str] = bar_less_stdout.split("\n")
+    stripped_of_floats: typing.List[str] = [
+        re.sub(r"-?\b\d+\.\d+s?\b", "<float>", text).rstrip() for text in lines
+    ]
+    return stripped_of_floats

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -69,16 +69,16 @@ def test_report_on_run_basic_call() -> None:
         run_command_stdout = buf.getvalue()
     assert run_command_stdout.split("\n") == [
         "runem: reports:",
-        "runem (total wall-clock)          [1000.500000]  ████████████████████████████████",
+        "runem (total wall-clock)  [1000.500000]  ████████████████████████████████",
         (
-            " └phase 1 (user-time)             [1252.001001] "
-            " ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"
+            " └phase 1 (user-time)     [1252.001001]  "
+            "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"
         ),
-        "  ├phase 1.job label 2            [1000.001001]  ████████████████████████████████",
-        "  │├phase 1.job label 2.sub1 (+)  [ 500.000000]  ················",
-        "  │└phase 1.job label 2.sub2 (+)  [ 500.000000]  ················",
-        "  ├phase 1.another job 3          [   2.000000]  ▏",
-        "  └phase 1.another job 4          [ 250.000000]  ████████",
+        "  ├job label 2            [1000.001001]  ████████████████████████████████",
+        "  │├sub1 (+)              [ 500.000000]  ················",
+        "  │└sub2 (+)              [ 500.000000]  ················",
+        "  ├another job 3          [   2.000000]  ▏",
+        "  └another job 4          [ 250.000000]  ████████",
         "",
     ]
     # this floating-point comparison should be problematic but its' working for
@@ -132,9 +132,15 @@ def test_report_on_run_reports() -> None:
     assert run_command_stdout.split("\n") == [
         "runem: reports:",
         "runem (total wall-clock)  [   0.000000]",
-        " └phase 1 (user-time)     [1002.001001]  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░",
-        "  ├phase 1.job label 2    [1000.001001]  ███████████████████████████████████████▉",
-        "  └phase 1.another job 3  [   2.000000]  ▏",
+        (
+            " └phase 1 (user-time)     [1002.001001]  "
+            "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"
+        ),
+        (
+            "  ├job label 2            [1000.001001]  "
+            "███████████████████████████████████████▉"
+        ),
+        "  └another job 3          [   2.000000]  ▏",
         "runem: report: dummy report label: /dummy/report/url",
         "",
     ]
@@ -179,20 +185,20 @@ def test_sanitise_reports_footer_removes_all_bar_chars_2() -> None:
         "runem: reports:",
         "runem (total wall-clock)  [ <float>]",
         " └phase 1 (user-time)     [<float>]",
-        "  ├phase 1.job 1          [  <float>]",
-        "  ├phase 1.job 2          [  <float>]",
-        "  ├phase 1.job 3          [  <float>]",
-        "  ├phase 1.job 4          [  <float>]",
-        "  ├phase 1.job 5          [  <float>]",
-        "  ├phase 1.job 6          [  <float>]",
-        "  ├phase 1.job 7          [  <float>]",
-        "  ├phase 1.job 8          [  <float>]",
-        "  ├phase 1.job 9          [  <float>]",
-        "  ├phase 1.job 10         [ <float>]",
-        "  ├phase 1.job 11         [ <float>]",
-        "  ├phase 1.job 12         [ <float>]",
-        "  ├phase 1.job 13         [ <float>]",
-        "  └phase 1.job 14         [ <float>]",
+        "  ├job 1                  [  <float>]",
+        "  ├job 2                  [  <float>]",
+        "  ├job 3                  [  <float>]",
+        "  ├job 4                  [  <float>]",
+        "  ├job 5                  [  <float>]",
+        "  ├job 6                  [  <float>]",
+        "  ├job 7                  [  <float>]",
+        "  ├job 8                  [  <float>]",
+        "  ├job 9                  [  <float>]",
+        "  ├job 10                 [ <float>]",
+        "  ├job 11                 [ <float>]",
+        "  ├job 12                 [ <float>]",
+        "  ├job 13                 [ <float>]",
+        "  └job 14                 [ <float>]",
         "",
     ]
     # this floating-point comparison should be problematic but its' working for


### PR DESCRIPTION
### Summary :memo:

Removes the duplicate information from the tree-report.

### Details

We make the tree-report neater and less noisy by removing the job 'address' for example:
- `<phase-name>.<job>` becomes just `<job>` 
- `<phase-name>.<job>.<sub-job>` becomes just `<sub-job>` 
Which we can do now because the jobs/sub-jobs are "hung" from their parent.

We also fix tests and typos.
