### PR TITLE
Feat/user local hooks (1st pass)

### DIFF
--- a/.runem.yml
+++ b/.runem.yml
@@ -55,6 +55,11 @@
           name: unit-test
           desc: run unit tests
           type: bool
+- hook:
+    hook_name: on-exit
+    addr:
+      file: scripts/test_hooks/runem_hooks.py
+      function: _on_exit_hook
 - job:
     addr:
       file: scripts/test_hooks/py.py

--- a/runem/config.py
+++ b/runem/config.py
@@ -77,9 +77,8 @@ def _conform_global_config_types(
     return all_config, global_config
 
 
-def load_config() -> typing.Tuple[Config, pathlib.Path]:
-    """Finds and loads the .runem.yml file."""
-    cfg_filepath: pathlib.Path = _find_cfg()
+def load_and_parse_config(cfg_filepath: pathlib.Path) -> Config:
+    """For the given config file pass, project or user, load it & parse/conform it."""
     with cfg_filepath.open("r+", encoding="utf-8") as config_file_handle:
         all_config = yaml.full_load(config_file_handle)
 
@@ -104,5 +103,12 @@ def load_config() -> typing.Tuple[Config, pathlib.Path]:
                 )
             )
             sys.exit(1)
+    return conformed_config
+
+
+def load_project_config() -> typing.Tuple[Config, pathlib.Path]:
+    """Finds and loads the .runem.yml file for the current project."""
+    cfg_filepath: pathlib.Path = _find_cfg()
+    conformed_config = load_and_parse_config(cfg_filepath)
 
     return conformed_config, cfg_filepath

--- a/runem/config.py
+++ b/runem/config.py
@@ -7,7 +7,7 @@ from packaging.version import Version
 
 from runem.log import log
 from runem.runem_version import get_runem_version
-from runem.types import Config, GlobalConfig, GlobalSerialisedConfig
+from runem.types import Config, GlobalConfig, GlobalSerialisedConfig, UserConfigMetadata
 
 CFG_FILE_YAML = pathlib.Path(".runem.yml")
 
@@ -40,18 +40,51 @@ def _search_up_multiple_dirs_for_file(
     return None
 
 
-def _find_cfg() -> pathlib.Path:
-    """Searches up from the cwd for a .runem.yml config file."""
+def _find_config_file(
+    config_filename: typing.Union[str, pathlib.Path]
+) -> typing.Tuple[typing.Optional[pathlib.Path], typing.Tuple[pathlib.Path, ...]]:
+    """Searches up from the cwd for the given config file-name."""
     start_dirs = (pathlib.Path(".").absolute(),)
     cfg_candidate: typing.Optional[pathlib.Path] = _search_up_multiple_dirs_for_file(
-        start_dirs, CFG_FILE_YAML
+        start_dirs, config_filename
     )
+    return cfg_candidate, start_dirs
+
+
+def _find_project_cfg() -> pathlib.Path:
+    """Searches up from the cwd for the project .runem.yml config file."""
+    cfg_candidate: typing.Optional[pathlib.Path]
+    start_dirs: typing.Tuple[pathlib.Path, ...]
+    cfg_candidate, start_dirs = _find_config_file(config_filename=CFG_FILE_YAML)
+
     if cfg_candidate:
         return cfg_candidate
 
     # error out and exit as we currently require the cfg file as it lists jobs.
     log(f"ERROR: Config not found! Looked from {start_dirs}")
     sys.exit(1)
+
+
+def _find_local_configs() -> typing.List[pathlib.Path]:
+    """Searches for all user-configs and returns the found ones.
+
+    TODO: add some priorities to the files, such that
+            - .runem.local.yml has lowest priority
+            - $HOME/.runem.user.yml is applied after .local
+            - .runem.user.yml overloads all others
+    """
+    local_configs: typing.List[pathlib.Path] = []
+    for config_filename in (".runem.local.yml", ".runem.user.yml"):
+        cfg_candidate: typing.Optional[pathlib.Path]
+        cfg_candidate, _ = _find_config_file(config_filename)
+        if cfg_candidate:
+            local_configs.append(cfg_candidate)
+
+    user_home_config: pathlib.Path = pathlib.Path("~/.runem.user.yml")
+    if user_home_config.exists():
+        local_configs.append(user_home_config)
+
+    return local_configs
 
 
 def _conform_global_config_types(
@@ -108,7 +141,17 @@ def load_and_parse_config(cfg_filepath: pathlib.Path) -> Config:
 
 def load_project_config() -> typing.Tuple[Config, pathlib.Path]:
     """Finds and loads the .runem.yml file for the current project."""
-    cfg_filepath: pathlib.Path = _find_cfg()
-    conformed_config = load_and_parse_config(cfg_filepath)
+    cfg_filepath: pathlib.Path = _find_project_cfg()
+    conformed_config: Config = load_and_parse_config(cfg_filepath)
 
     return conformed_config, cfg_filepath
+
+
+def load_user_configs() -> UserConfigMetadata:
+    """Returns the user-local configs, that extend/override runem behaviour."""
+    user_configs: typing.List[typing.Tuple[Config, pathlib.Path]] = []
+    user_config_paths: typing.List[pathlib.Path] = _find_local_configs()
+    for config_path in user_config_paths:
+        user_config: Config = load_and_parse_config(config_path)
+        user_configs.append((user_config, config_path))
+    return user_configs

--- a/runem/config_metadata.py
+++ b/runem/config_metadata.py
@@ -1,5 +1,6 @@
 import argparse
 import pathlib
+import typing
 
 from runem.informative_dict import InformativeDict
 from runem.types import (
@@ -13,6 +14,9 @@ from runem.types import (
     TagFileFilters,
 )
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from runem.hook_manager import HookManager
+
 
 class ConfigMetadata:
     """Full metadata about what can and should be run."""
@@ -20,6 +24,7 @@ class ConfigMetadata:
     phases: OrderedPhases  # the phases and orders to run them in
     options_config: OptionConfigs  # the options to add to the cli and pass to jobs
     file_filters: TagFileFilters  # which files to get for which tag
+    hook_manager: "HookManager"  # the hooks register for the run
     jobs: PhaseGroupedJobs  # the jobs to be run ordered by phase
     all_job_names: JobNames  # the set of job-names
     all_job_phases: JobPhases  # the set of job-phases (should be subset of 'phases')
@@ -39,6 +44,7 @@ class ConfigMetadata:
         phases: OrderedPhases,
         options_config: OptionConfigs,
         file_filters: TagFileFilters,
+        hook_manager: "HookManager",
         jobs: PhaseGroupedJobs,
         all_job_names: JobNames,
         all_job_phases: JobPhases,
@@ -48,6 +54,8 @@ class ConfigMetadata:
         self.phases = phases
         self.options_config = options_config
         self.file_filters = file_filters
+        # initialise all the registered call-back hooks
+        self.hook_manager = hook_manager
         self.jobs = jobs
         self.all_job_names = all_job_names
         self.all_job_phases = all_job_phases

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -73,20 +73,22 @@ def parse_hook_config(
 ) -> None:
     """Get the hook information, verifying validity."""
     try:
-        hook_name: HookName = HookName(hook["hook_name"])
-        if not HookManager.is_valid_hook_name(hook_name):
+        if not HookManager.is_valid_hook_name(hook["hook_name"]):
             raise ValueError(
-                f"invalid hook-name '{hook_name}'. "
+                f"invalid hook-name '{str(hook['hook_name'])}'. "
                 f"Valid hook names are: {[hook.value for hook in HookName]}"
             )
-        hook["hook_name"] = hook_name
+        # cast the hook-name to a HookName type
+        hook["hook_name"] = HookName(hook["hook_name"])
         get_job_wrapper(hook, cfg_filepath)
     except KeyError as err:
         raise ValueError(
             f"hook config entry is missing '{err.args[0]}' key. Have {tuple(hook.keys())}"
         ) from err
     except FunctionNotFound as err:
-        raise FunctionNotFound(f"Whilst loading job '{hook_name}'. {str(err)}") from err
+        raise FunctionNotFound(
+            f"Whilst loading job '{str(hook['hook_name'])}'. {str(err)}"
+        ) from err
 
 
 def _parse_job(  # noqa: C901

--- a/runem/hook_manager.py
+++ b/runem/hook_manager.py
@@ -1,0 +1,112 @@
+import typing
+from collections import defaultdict
+
+from runem.config_metadata import ConfigMetadata
+from runem.job import Job
+from runem.job_execute import job_execute
+from runem.log import log
+from runem.types import (
+    FilePathListLookup,
+    HookConfig,
+    HookName,
+    Hooks,
+    HooksStore,
+    JobConfig,
+)
+
+
+class HookManager:
+    hooks_store: HooksStore
+
+    def __init__(self, hooks: Hooks, verbose: bool) -> None:
+        self.hooks_store: HooksStore = defaultdict(list)
+        self.initialise_hooks(hooks, verbose)
+
+    @staticmethod
+    def is_valid_hook_name(hook_name: typing.Union[HookName, str]) -> bool:
+        """Returns True/False depending on hook-name validity."""
+        if isinstance(hook_name, str):
+            try:
+                HookName(hook_name)  # lookup by value
+                return True
+            except ValueError:
+                return False
+        # the type is a HookName
+        assert isinstance(hook_name, HookName)
+        return True
+
+    def register_hook(
+        self, hook_name: HookName, hook_config: HookConfig, verbose: bool
+    ) -> None:
+        """Registers a hook_config to a specific hook-type."""
+        if not self.is_valid_hook_name(hook_name):
+            raise ValueError(f"Hook {hook_name} does not exist.")
+        self.hooks_store[hook_name].append(hook_config)
+        if verbose:
+            log(
+                f"hooks: registered hook for '{hook_name}', "
+                f"have {len(self.hooks_store[hook_name])}: "
+                f"{Job.get_job_name(hook_config)}"  # type: ignore[arg-type]
+            )
+
+    def deregister_hook(
+        self, hook_name: HookName, hook_config: HookConfig, verbose: bool
+    ) -> None:
+        """Deregisters a hook_config from a specific hook-type."""
+        if not (
+            hook_name in self.hooks_store and hook_config in self.hooks_store[hook_name]
+        ):
+            raise ValueError(f"Function not found in hook {hook_name}.")
+        self.hooks_store[hook_name].remove(hook_config)
+        if verbose:
+            log(
+                f"hooks: deregistered hooks for '{hook_name}', "
+                f"have {len(self.hooks_store[hook_name])}"
+            )
+
+    def invoke_hooks(
+        self,
+        hook_name: HookName,
+        config_metadata: ConfigMetadata,
+        **kwargs: typing.Any,
+    ) -> None:
+        """Invokes all functions registered to a specific hook."""
+        hooks: typing.List[HookConfig] = self.hooks_store.get(hook_name, [])
+        if config_metadata.args.verbose:
+            log(f"hooks: invoking {len(hooks)} hooks for '{hook_name}'")
+
+        hook_config: HookConfig
+        for hook_config in hooks:
+            job_config: JobConfig = {
+                "label": str(hook_name),
+                "ctx": None,
+                "when": {"phase": str(hook_name), "tags": {str(hook_name)}},
+            }
+            if "addr" in hook_config:
+                job_config["addr"] = hook_config["addr"]
+            if "command" in hook_config:
+                job_config["command"] = hook_config["command"]
+            file_lists: FilePathListLookup = defaultdict(list)
+            file_lists[str(hook_name)] = [__file__]
+            job_execute(
+                job_config,
+                running_jobs={},
+                config_metadata=config_metadata,
+                file_lists=file_lists,
+                **kwargs,
+            )
+
+        if config_metadata.args.verbose:
+            log(f"hooks: done invoking '{hook_name}'")
+
+    def initialise_hooks(self, hooks: Hooks, verbose: bool) -> None:
+        """Initialised the hook with the configured data."""
+        if verbose:
+            num_hooks: int = sum(len(hooks_list) for hooks_list in hooks.values())
+            if num_hooks:
+                log(f"hooks: initialising {num_hooks} hooks")
+        for hook_name in hooks:
+            hook: HookConfig
+            log(f"hooks:\tinitialising {len(hooks[hook_name])} hooks for '{hook_name}'")
+            for hook in hooks[hook_name]:
+                self.register_hook(hook_name, hook, verbose)

--- a/runem/hook_manager.py
+++ b/runem/hook_manager.py
@@ -107,6 +107,9 @@ class HookManager:
                 log(f"hooks: initialising {num_hooks} hooks")
         for hook_name in hooks:
             hook: HookConfig
-            log(f"hooks:\tinitialising {len(hooks[hook_name])} hooks for '{hook_name}'")
+            if verbose:
+                log(
+                    f"hooks:\tinitialising {len(hooks[hook_name])} hooks for '{hook_name}'"
+                )
             for hook in hooks[hook_name]:
                 self.register_hook(hook_name, hook, verbose)

--- a/runem/hook_manager.py
+++ b/runem/hook_manager.py
@@ -32,7 +32,8 @@ class HookManager:
             except ValueError:
                 return False
         # the type is a HookName
-        assert isinstance(hook_name, HookName)
+        if not isinstance(hook_name, HookName):
+            return False
         return True
 
     def register_hook(

--- a/runem/job_filter.py
+++ b/runem/job_filter.py
@@ -35,7 +35,7 @@ def _should_filter_out_by_tags(
         if verbose:
             log(
                 (
-                    f"not running job '{job['label']}' because it doesn't have "
+                    f"not running job '{Job.get_job_name(job)}' because it doesn't have "
                     f"any of the following tags: {printable_set(tags)}"
                 )
             )
@@ -46,7 +46,7 @@ def _should_filter_out_by_tags(
         if verbose:
             log(
                 (
-                    f"not running job '{job['label']}' because it contains the "
+                    f"not running job '{Job.get_job_name(job)}' because it contains the "
                     f"following tags: {printable_set(has_tags_to_avoid)}"
                 )
             )

--- a/runem/job_runner_simple_command.py
+++ b/runem/job_runner_simple_command.py
@@ -5,6 +5,12 @@ from runem.run_command import run_command
 from runem.types import JobConfig
 
 
+def validate_simple_command(command_string: str) -> typing.List[str]:
+    # use shlex to handle parsing of the command string, a non-trivial problem.
+    split_command: typing.List[str] = shlex.split(command_string)
+    return split_command
+
+
 def job_runner_simple_command(
     **kwargs: typing.Any,
 ) -> None:
@@ -17,7 +23,7 @@ def job_runner_simple_command(
     command_string: str = job_config["command"]
 
     # use shlex to handle parsing of the command string, a non-trivial problem.
-    result = shlex.split(command_string)
+    result = validate_simple_command(command_string)
 
     # preserve quotes for consistent handling of strings and avoid the "word
     # splitting" problem for unix-like shells.

--- a/runem/job_wrapper.py
+++ b/runem/job_wrapper.py
@@ -1,19 +1,25 @@
 import pathlib
 
-from runem.job_runner_simple_command import job_runner_simple_command
+from runem.job_runner_simple_command import (
+    job_runner_simple_command,
+    validate_simple_command,
+)
 from runem.job_wrapper_python import get_job_wrapper_py_func
-from runem.types import JobConfig, JobFunction
+from runem.types import JobFunction, JobWrapper
 
 
-def get_job_wrapper(job_config: JobConfig, cfg_filepath: pathlib.Path) -> JobFunction:
+def get_job_wrapper(job_wrapper: JobWrapper, cfg_filepath: pathlib.Path) -> JobFunction:
     """Given a job-description determines the job-runner, returning it as a function.
 
     NOTE: Side-effects: also re-addressed the job-config in the case of functions see
           get_job_function.
     """
-    if "command" in job_config:
+    if "command" in job_wrapper:
+        # validate that the command is "understandable" and usable.
+        command_string: str = job_wrapper["command"]
+        validate_simple_command(command_string)
         return job_runner_simple_command  # type: ignore # NO_COMMIT
 
     # if we do not have a simple command address assume we have just an addressed
     # function
-    return get_job_wrapper_py_func(job_config, cfg_filepath)
+    return get_job_wrapper_py_func(job_wrapper, cfg_filepath)

--- a/runem/job_wrapper_python.py
+++ b/runem/job_wrapper_python.py
@@ -3,7 +3,7 @@ import sys
 from importlib.util import module_from_spec
 from importlib.util import spec_from_file_location as module_spec_from_file_location
 
-from runem.types import FunctionNotFound, JobConfig, JobFunction
+from runem.types import FunctionNotFound, JobFunction, JobWrapper
 
 
 def _load_python_function_from_module(
@@ -86,22 +86,22 @@ def _find_job_module(cfg_filepath: pathlib.Path, module_file_path: str) -> pathl
 
 
 def get_job_wrapper_py_func(
-    job_config: JobConfig, cfg_filepath: pathlib.Path
+    job_wrapper: JobWrapper, cfg_filepath: pathlib.Path
 ) -> JobFunction:
     """For a job, dynamically loads the associated python job-function.
 
     Side-effects: also re-addressed the job-config.
     """
-    function_to_load: str = job_config["addr"]["function"]
+    function_to_load: str = job_wrapper["addr"]["function"]
     try:
         module_file_path: pathlib.Path = _find_job_module(
-            cfg_filepath, job_config["addr"]["file"]
+            cfg_filepath, job_wrapper["addr"]["file"]
         )
     except FunctionNotFound as err:
         raise FunctionNotFound(
             (
-                f"Whilst loading job '{job_config['label']}' runem failed to find "
-                f"job.addr.file '{job_config['addr']['file']}' looking for "
+                "runem failed to find "
+                f"job.addr.file '{job_wrapper['addr']['file']}' looking for "
                 f"job.addr.function '{function_to_load}'"
             )
         ) from err
@@ -118,5 +118,5 @@ def get_job_wrapper_py_func(
     )
 
     # re-write the job-config file-path for the module with the one that worked
-    job_config["addr"]["file"] = str(module_file_path)
+    job_wrapper["addr"]["file"] = str(module_file_path)
     return function

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -34,7 +34,7 @@ from timeit import default_timer as timer
 from halo import Halo
 
 from runem.command_line import parse_args
-from runem.config import load_project_config
+from runem.config import load_project_config, load_user_configs
 from runem.config_metadata import ConfigMetadata
 from runem.config_parse import load_config_metadata
 from runem.files import find_files
@@ -70,8 +70,9 @@ def _determine_run_parameters(argv: typing.List[str]) -> ConfigMetadata:
     config: Config
     cfg_filepath: pathlib.Path
     config, cfg_filepath = load_project_config()
+    user_configs: typing.List[typing.Tuple[Config, pathlib.Path]] = load_user_configs()
     config_metadata: ConfigMetadata = load_config_metadata(
-        config, cfg_filepath, verbose=("--verbose" in argv)
+        config, cfg_filepath, user_configs, verbose=("--verbose" in argv)
     )
 
     # Now we parse the cli arguments extending them with information from the

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -36,7 +36,7 @@ from halo import Halo
 from runem.command_line import parse_args
 from runem.config import load_config
 from runem.config_metadata import ConfigMetadata
-from runem.config_parse import parse_config
+from runem.config_parse import load_config_metadata
 from runem.files import find_files
 from runem.job import Job
 from runem.job_execute import job_execute
@@ -70,7 +70,7 @@ def _determine_run_parameters(argv: typing.List[str]) -> ConfigMetadata:
     config: Config
     cfg_filepath: pathlib.Path
     config, cfg_filepath = load_config()
-    config_metadata: ConfigMetadata = parse_config(
+    config_metadata: ConfigMetadata = load_config_metadata(
         config, cfg_filepath, verbose=("--verbose" in argv)
     )
 

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -34,7 +34,7 @@ from timeit import default_timer as timer
 from halo import Halo
 
 from runem.command_line import parse_args
-from runem.config import load_config
+from runem.config import load_project_config
 from runem.config_metadata import ConfigMetadata
 from runem.config_parse import load_config_metadata
 from runem.files import find_files
@@ -69,7 +69,7 @@ def _determine_run_parameters(argv: typing.List[str]) -> ConfigMetadata:
     """
     config: Config
     cfg_filepath: pathlib.Path
-    config, cfg_filepath = load_config()
+    config, cfg_filepath = load_project_config()
     config_metadata: ConfigMetadata = load_config_metadata(
         config, cfg_filepath, verbose=("--verbose" in argv)
     )

--- a/runem/types.py
+++ b/runem/types.py
@@ -2,6 +2,7 @@ import argparse
 import pathlib
 import typing
 from datetime import timedelta
+from enum import Enum
 
 from runem.informative_dict import InformativeDict, ReadOnlyInformativeDict
 
@@ -24,6 +25,15 @@ ReportName = str
 ReportUrl = typing.Union[str, pathlib.Path]
 ReportUrlInfo = typing.Tuple[ReportName, ReportUrl]
 ReportUrls = typing.List[ReportUrlInfo]
+
+
+class HookName(Enum):
+    # at exit
+    ON_EXIT = "on-exit"
+    # before all tasks are run, after config is read
+    # BEFORE_ALL = "before-all"
+    # after all tasks are done, before reporting
+    # AFTER_ALL = "after-all"
 
 
 class JobReturnData(typing.TypedDict, total=False):
@@ -125,7 +135,14 @@ class JobWhen(typing.TypedDict, total=False):
     phase: PhaseName  # the phase when the job should be run
 
 
-class JobConfig(typing.TypedDict, total=False):
+class JobWrapper(typing.TypedDict, total=False):
+    """A base-type for jobs, hooks, and things that can be invoked."""
+
+    addr: JobAddressConfig  # which callable to call
+    command: str  # a one-liner command to be run
+
+
+class JobConfig(JobWrapper, total=False):
     """A dict that defines a job to be run.
 
     It consists of the label, address, context and filter information
@@ -134,8 +151,6 @@ class JobConfig(typing.TypedDict, total=False):
     """
 
     label: JobName  # the name of the job
-    addr: JobAddressConfig  # which callable to call
-    command: str  # a one-liner command to be run
     ctx: typing.Optional[JobContextConfig]  # how to call the callable
     when: JobWhen  # when to call the job
 
@@ -193,6 +208,30 @@ class GlobalSerialisedConfig(typing.TypedDict):
     config: GlobalConfig
 
 
+class HookConfig(JobWrapper, total=False):
+    """Specification for hooks.
+
+    Like JobConfig with use addr or command to specify what to execute.
+    """
+
+    hook_name: HookName  # the hook for when this is called
+
+
+Hooks = typing.DefaultDict[HookName, typing.List[HookConfig]]
+
+# A dictionary to hold hooks, with hook names as keys
+HooksStore = typing.Dict[HookName, typing.List[HookConfig]]
+
+
+class HookSerialisedConfig(typing.TypedDict):
+    """Intended to make reading a config file easier.
+
+    Also, unlike JobSerialisedConfig, this type may not actually help readability.
+    """
+
+    hook: HookConfig
+
+
 class JobSerialisedConfig(typing.TypedDict):
     """Makes serialised configs easier to read.
 
@@ -204,6 +243,8 @@ class JobSerialisedConfig(typing.TypedDict):
     job: JobConfig
 
 
-ConfigNodes = typing.Union[GlobalSerialisedConfig, JobSerialisedConfig]
+ConfigNodes = typing.Union[
+    GlobalSerialisedConfig, JobSerialisedConfig, HookSerialisedConfig
+]
 # The config format as it is serialised to/from disk
 Config = typing.List[ConfigNodes]

--- a/runem/types.py
+++ b/runem/types.py
@@ -248,3 +248,5 @@ ConfigNodes = typing.Union[
 ]
 # The config format as it is serialised to/from disk
 Config = typing.List[ConfigNodes]
+
+UserConfigMetadata = typing.List[typing.Tuple[Config, pathlib.Path]]

--- a/scripts/test_hooks/runem_hooks.py
+++ b/scripts/test_hooks/runem_hooks.py
@@ -1,0 +1,15 @@
+import pathlib
+import typing
+from datetime import timedelta
+
+
+def _on_exit_hook(
+    wall_clock_time_saved: timedelta,
+    **kwargs: typing.Any,
+) -> None:
+    """A noddy hook."""
+    root_path: pathlib.Path = pathlib.Path(__file__).parent.parent.parent
+    assert (root_path / ".runem.yml").exists()
+    times_log: pathlib.Path = root_path / ".times.log"
+    with times_log.open("a", encoding="utf-8") as file:
+        file.write(f"{str(wall_clock_time_saved.total_seconds())}\n")

--- a/tests/cli/test_initialise_options.py
+++ b/tests/cli/test_initialise_options.py
@@ -2,6 +2,7 @@ import pathlib
 from argparse import Namespace
 from collections import defaultdict
 from typing import Dict
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -45,6 +46,7 @@ def config_metadata_fixture() -> ConfigMetadata:
             #     "regex": ".*1.txt",  # should match just one file
             # }
         },
+        hook_manager=MagicMock(),
         jobs=expected_jobs,
         all_job_names=set(("dummy job label",)),
         all_job_phases=set(("dummy phase 1",)),

--- a/tests/data/help_output.3.11.txt
+++ b/tests/data/help_output.3.11.txt
@@ -1,4 +1,8 @@
 runem: WARNING: no phase found for 'echo "hello world!"', using 'dummy phase 1'
+runem: hooks: initialising 2 hooks
+runem: hooks:	initialising 2 hooks for 'HookName.ON_EXIT'
+runem: hooks: registered hook for 'HookName.ON_EXIT', have 1: echo 'mock user local hook'
+runem: hooks: registered hook for 'HookName.ON_EXIT', have 2: echo 'mock user home-dir hook'
 usage: -c [-h] [--jobs JOBS [JOBS ...]]
           [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]]
           [--phases PHASES [PHASES ...]]

--- a/tests/data/help_output.3.11.txt
+++ b/tests/data/help_output.3.11.txt
@@ -1,8 +1,4 @@
 runem: WARNING: no phase found for 'echo "hello world!"', using 'dummy phase 1'
-runem: hooks: initialising 2 hooks
-runem: hooks:	initialising 2 hooks for 'HookName.ON_EXIT'
-runem: hooks: registered hook for 'HookName.ON_EXIT', have 1: echo 'mock user local hook'
-runem: hooks: registered hook for 'HookName.ON_EXIT', have 2: echo 'mock user home-dir hook'
 usage: -c [-h] [--jobs JOBS [JOBS ...]]
           [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]]
           [--phases PHASES [PHASES ...]]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -168,6 +168,22 @@ def test_find_local_configs(
 
 
 @patch(
+    "runem.config._find_config_file",
+    return_value=(None, None),
+)
+@patch("pathlib.Path.exists", return_value=False)
+def test_find_local_configs_finds_nothing(
+    path_exists_mock: Mock,
+    find_config_file_mock: Mock,
+) -> None:
+    configs: typing.List[pathlib.Path] = _find_local_configs()
+    assert len(configs) == 0
+    assert not configs
+    find_config_file_mock.assert_called()
+    path_exists_mock.assert_called()
+
+
+@patch(
     "runem.config.load_and_parse_config",
     return_value="DUMMY CONFIG",
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,11 +5,11 @@ from contextlib import redirect_stdout
 
 import pytest
 
-from runem.config import load_config
+from runem.config import load_project_config
 from runem.types import Config, GlobalConfig
 
 
-def test_load_config(tmp_path: pathlib.Path) -> None:
+def test_load_project_config(tmp_path: pathlib.Path) -> None:
     config_gen_path: pathlib.Path = tmp_path / ".runem.yml"
     config_gen_path.write_text(
         "- config:\n"
@@ -25,7 +25,7 @@ def test_load_config(tmp_path: pathlib.Path) -> None:
 
     loaded_config: Config
     config_read_path: pathlib.Path
-    loaded_config, config_read_path = load_config()
+    loaded_config, config_read_path = load_project_config()
     expected_config: Config = [
         {
             "config": {
@@ -40,7 +40,7 @@ def test_load_config(tmp_path: pathlib.Path) -> None:
     assert config_read_path == config_gen_path
 
 
-def test_load_config_with_no_phases(tmp_path: pathlib.Path) -> None:
+def test_load_project_config_with_no_phases(tmp_path: pathlib.Path) -> None:
     config_gen_path: pathlib.Path = tmp_path / ".runem.yml"
     config_gen_path.write_text(
         (
@@ -55,7 +55,7 @@ def test_load_config_with_no_phases(tmp_path: pathlib.Path) -> None:
 
     loaded_config: Config
     config_read_path: pathlib.Path
-    loaded_config, config_read_path = load_config()
+    loaded_config, config_read_path = load_project_config()
     expected_config: Config = [
         {
             "config": {  # type: ignore # intentionally testing for missing 'phases'
@@ -68,7 +68,7 @@ def test_load_config_with_no_phases(tmp_path: pathlib.Path) -> None:
     assert config_read_path == config_gen_path
 
 
-def test_load_config_with_min_version(tmp_path: pathlib.Path) -> None:
+def test_load_project_config_with_min_version(tmp_path: pathlib.Path) -> None:
     config_gen_path: pathlib.Path = tmp_path / ".runem.yml"
     config_gen_path.write_text(
         (
@@ -84,7 +84,7 @@ def test_load_config_with_min_version(tmp_path: pathlib.Path) -> None:
 
     with io.StringIO() as buf, redirect_stdout(buf):
         with pytest.raises(SystemExit):
-            load_config()
+            load_project_config()
         runem_stdout: str = buf.getvalue()
         assert (
             "runem: .runem.yml config requires runem '9999.99999.9999', you have"
@@ -92,7 +92,7 @@ def test_load_config_with_min_version(tmp_path: pathlib.Path) -> None:
         )
 
 
-def test_load_config_with_global_last(tmp_path: pathlib.Path) -> None:
+def test_load_project_config_with_global_last(tmp_path: pathlib.Path) -> None:
     config_gen_path: pathlib.Path = tmp_path / ".runem.yml"
     config_gen_path.write_text(
         (
@@ -118,7 +118,7 @@ def test_load_config_with_global_last(tmp_path: pathlib.Path) -> None:
 
     loaded_config: Config
     config_read_path: pathlib.Path
-    loaded_config, config_read_path = load_config()
+    loaded_config, config_read_path = load_project_config()
     global_config: GlobalConfig = {  # type: ignore # intentionally testing for missing 'phases'
         "files": None,
         "options": None,

--- a/tests/test_config_parse.py
+++ b/tests/test_config_parse.py
@@ -1,5 +1,6 @@
 import io
 import pathlib
+import typing
 import unittest
 from collections import defaultdict
 from contextlib import redirect_stdout
@@ -825,7 +826,7 @@ def test_parse_hook_config_with_in_valid_hook_name() -> None:
     cfg_filepath = pathlib.Path(__file__)
     hook: HookConfig = {
         "command": "echo 'test hook command'",
-        "hook_name": "bd-hook-name",  # type: ignore
+        "hook_name": "bad-hook-name",  # type: ignore
     }
     with pytest.raises(ValueError):
         parse_hook_config(hook, cfg_filepath)
@@ -862,4 +863,21 @@ def test_parse_hook_config_with_bad_function_address() -> None:
         "hook_name": HookName("on-exit"),
     }
     with pytest.raises(FunctionNotFound):
+        parse_hook_config(hook, cfg_filepath)
+
+
+@pytest.mark.parametrize(
+    "hook_type",
+    [
+        "non-existent-hook",
+        123,
+    ],
+)
+def test_parse_hook_config_with_bad_hook_name_types(hook_type: typing.Any) -> None:
+    cfg_filepath = pathlib.Path(__file__)
+    hook: HookConfig = {
+        "command": "echo 'test hook command'",
+        "hook_name": hook_type,
+    }
+    with pytest.raises(ValueError):
         parse_hook_config(hook, cfg_filepath)

--- a/tests/test_config_parse.py
+++ b/tests/test_config_parse.py
@@ -11,7 +11,7 @@ from runem.config_metadata import ConfigMetadata
 from runem.config_parse import (
     _parse_global_config,
     _parse_job,
-    parse_config,
+    load_config_metadata,
     parse_hook_config,
     parse_job_config,
 )
@@ -289,7 +289,7 @@ def test_parse_global_config_full() -> None:
     assert file_filters == {"dummy tag": {"regex": ".*", "tag": "dummy tag"}}
 
 
-def test_parse_config() -> None:
+def test_load_config_metadata() -> None:
     """Test parsing works for a full config."""
     global_config: GlobalSerialisedConfig = {
         "config": {
@@ -303,7 +303,7 @@ def test_parse_config() -> None:
         "job": {
             "addr": {
                 "file": __file__,
-                "function": "test_parse_config",
+                "function": "test_load_config_metadata",
             },
             "label": "dummy job label",
             "when": {
@@ -328,7 +328,7 @@ def test_parse_config() -> None:
     expected_job: JobConfig = {
         "addr": {
             "file": "test_config_parse.py",
-            "function": "test_parse_config",
+            "function": "test_load_config_metadata",
         },
         "label": "dummy job label",
         "when": {
@@ -362,7 +362,7 @@ def test_parse_config() -> None:
         ),
     )
 
-    result: ConfigMetadata = parse_config(full_config, config_file_path)
+    result: ConfigMetadata = load_config_metadata(full_config, config_file_path)
     assert result.phases == expected_config_metadata.phases
     assert result.options_config == expected_config_metadata.options_config
     assert result.file_filters == expected_config_metadata.file_filters
@@ -372,7 +372,7 @@ def test_parse_config() -> None:
     assert result.all_job_tags == expected_config_metadata.all_job_tags
 
 
-def test_parse_config_raises_on_invalid() -> None:
+def test_load_config_metadata_raises_on_invalid() -> None:
     """Test throws for an invalid config."""
     invalid_config_spec: GlobalSerialisedConfig = {  # type: ignore
         "invalid": None,
@@ -383,10 +383,10 @@ def test_parse_config_raises_on_invalid() -> None:
     config_file_path = pathlib.Path(__file__).parent / ".runem.yml"
 
     with pytest.raises(RuntimeError):
-        parse_config(invalid_config, config_file_path)
+        load_config_metadata(invalid_config, config_file_path)
 
 
-def test_parse_config_duplicated_global_raises() -> None:
+def test_load_config_metadata_duplicated_global_raises() -> None:
     """Test the global config parse raises with duplicated global config."""
     dummy_global_config: GlobalSerialisedConfig = {
         "config": {
@@ -412,10 +412,10 @@ def test_parse_config_duplicated_global_raises() -> None:
     ]
     config_file_path = pathlib.Path(__file__).parent / ".runem.yml"
     with pytest.raises(ValueError):
-        parse_config(invalid_config, config_file_path)
+        load_config_metadata(invalid_config, config_file_path)
 
 
-def test_parse_config_empty_phases_raises() -> None:
+def test_load_config_metadata_empty_phases_raises() -> None:
     """Test the global config raises if the phases are empty."""
     dummy_global_config: GlobalSerialisedConfig = {
         "config": {
@@ -441,10 +441,10 @@ def test_parse_config_empty_phases_raises() -> None:
     ]
     config_file_path = pathlib.Path(__file__).parent / ".runem.yml"
     with pytest.raises(ValueError):
-        parse_config(invalid_config, config_file_path)
+        load_config_metadata(invalid_config, config_file_path)
 
 
-def test_parse_config_missing_phases_raises() -> None:
+def test_load_config_metadata_missing_phases_raises() -> None:
     """Test the global config raises if the phases are missing."""
     dummy_global_config: GlobalSerialisedConfig = {
         "config": {  # type: ignore
@@ -468,14 +468,14 @@ def test_parse_config_missing_phases_raises() -> None:
     ]
     config_file_path = pathlib.Path(__file__).parent / ".runem.yml"
     with pytest.raises(ValueError):
-        parse_config(invalid_config, config_file_path)
+        load_config_metadata(invalid_config, config_file_path)
 
 
 @patch(
     "runem.config_parse._parse_global_config",
     return_value=(None, (), {}),
 )
-def test_parse_config_warning_if_missing_phase_order(
+def test_load_config_metadata_warning_if_missing_phase_order(
     mock_parse_global_config: unittest.mock.Mock,
 ) -> None:
     """Test the global config raises if the phases are missing."""
@@ -502,7 +502,7 @@ def test_parse_config_warning_if_missing_phase_order(
 
     # run the command and capture output
     with io.StringIO() as buf, redirect_stdout(buf):
-        parse_config(valid_config, config_file_path)
+        load_config_metadata(valid_config, config_file_path)
         run_command_stdout = buf.getvalue()
 
     assert run_command_stdout.split("\n") == [

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,6 +1,6 @@
 import pathlib
 from collections import defaultdict
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from runem.config_metadata import ConfigMetadata
 from runem.files import find_files
@@ -22,6 +22,7 @@ def test_find_files_basic(mock_subprocess_check_output: Mock) -> None:
                 "regex": ".*1.txt",  # should match just one file
             }
         },
+        hook_manager=MagicMock(),
         jobs=defaultdict(list),
         all_job_names=set(),
         all_job_phases=set(),

--- a/tests/test_hook_manager.py
+++ b/tests/test_hook_manager.py
@@ -1,0 +1,183 @@
+import io
+import pathlib
+import typing
+from argparse import Namespace
+from collections import defaultdict
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import pytest
+
+from runem.config_metadata import ConfigMetadata
+from runem.hook_manager import HookManager
+from runem.informative_dict import InformativeDict
+from runem.types import HookConfig, HookName, Hooks, PhaseGroupedJobs
+
+mock_hook_function: HookConfig = {
+    "command": "echo 'test hook command'",
+    "hook_name": HookName("on-exit"),
+}
+
+
+@pytest.fixture(name="hook_man", autouse=True)
+def hook_manager_fixture() -> typing.Generator[HookManager, None, None]:
+    """Fixture to clean hooks dictionary before each test."""
+    dummy_hooks: Hooks = defaultdict(list)
+    hook_manager: HookManager = HookManager(dummy_hooks, verbose=False)
+    yield hook_manager
+
+
+@pytest.fixture(name="mock_timer", autouse=True)
+def create_mock_print_sleep() -> typing.Generator[None, None, None]:
+    with patch("runem.job_execute.timer", return_value=0.0):  # as mock_timer
+        yield
+
+
+def test_hook_lookup_by_name(hook_man: HookManager) -> None:
+    assert hook_man.is_valid_hook_name("on-exit")
+
+
+def test_hook_lookup_by_name_for_bad_name(hook_man: HookManager) -> None:
+    assert not hook_man.is_valid_hook_name("non-existent-hook-name")
+
+
+def test_register_hook(hook_man: HookManager) -> None:
+    """Test registering a hook function."""
+    hook_man.register_hook(HookName.ON_EXIT, mock_hook_function, verbose=False)
+    assert mock_hook_function in hook_man.hooks_store[HookName.ON_EXIT]
+
+
+@pytest.mark.parametrize(
+    "verbosity",
+    [
+        True,
+        False,
+    ],
+)
+def test_deregister_hook(verbosity: bool, hook_man: HookManager) -> None:
+    """Test deregistering a hook function."""
+
+    # run the command and capture output
+    with io.StringIO() as buf, redirect_stdout(buf):
+        hook_man.register_hook(HookName.ON_EXIT, mock_hook_function, verbose=verbosity)
+        hook_man.deregister_hook(
+            HookName.ON_EXIT, mock_hook_function, verbose=verbosity
+        )
+        run_command_stdout = buf.getvalue()
+    assert mock_hook_function not in hook_man.hooks_store[HookName.ON_EXIT]
+
+    stdout_lines = run_command_stdout.split("\n")
+    if not verbosity:
+        assert stdout_lines == [""]
+    else:
+        assert stdout_lines == [
+            "runem: hooks: registered hook for 'HookName.ON_EXIT', have 1: echo 'test "
+            "hook command'",
+            "runem: hooks: deregistered hooks for 'HookName.ON_EXIT', have 0",
+            "",
+        ]
+
+
+class IntentionalError(Exception):
+    pass
+
+
+def _dummy_hook(**kwargs: typing.Any) -> None:
+    print("mock_hook_function_function called aok")
+
+
+def test_invoke_hooks(hook_man: HookManager) -> None:
+    """Test invoking hook functions."""
+    mock_hook_function_py_callable: HookConfig = {
+        "addr": {"file": __file__, "function": "_dummy_hook"},
+        "hook_name": HookName("on-exit"),
+    }
+
+    mock_hook_function_bash: HookConfig = {
+        "command": 'echo "mock_hook_function_bash called aok"',
+        "hook_name": HookName("on-exit"),
+    }
+    hooks: Hooks = defaultdict(list)
+    hooks[HookName.ON_EXIT].append(mock_hook_function_py_callable)
+    hooks[HookName.ON_EXIT].append(mock_hook_function_bash)
+
+    jobs_by_phase: PhaseGroupedJobs = defaultdict(list)
+    all_job_names = ()
+    all_phase_names = ()
+    config_metadata: ConfigMetadata = ConfigMetadata(
+        cfg_filepath=pathlib.Path(__file__),
+        phases=all_phase_names,
+        options_config=tuple(),
+        file_filters={},
+        hook_manager=hook_man,
+        jobs=jobs_by_phase,
+        all_job_names=set(all_job_names),
+        all_job_phases=set(("dummy phase 1",)),
+        all_job_tags=set(),
+    )
+
+    config_metadata.set_cli_data(
+        args=Namespace(verbose=True, procs=1),
+        jobs_to_run=set(all_job_names),  # JobNames,
+        phases_to_run=set(all_phase_names),  # JobPhases,
+        tags_to_run=set(),  # ignored JobTags,
+        tags_to_avoid=set(),  # ignored  JobTags,
+        options=InformativeDict({}),  # Options,
+    )
+
+    # run the command and capture output
+    with io.StringIO() as buf, redirect_stdout(buf):
+        hook_man.initialise_hooks(hooks, verbose=True)
+        hook_man.invoke_hooks(HookName.ON_EXIT, config_metadata)
+        run_command_stdout = buf.getvalue()
+
+    run_command_stdout = run_command_stdout.replace(__file__, "<THIS_FILE>")
+    assert run_command_stdout.split("\n") == [
+        "runem: hooks: initialising 2 hooks",
+        "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
+        (
+            "runem: hooks: registered hook for 'HookName.ON_EXIT', have 1: "
+            "<THIS_FILE>._dummy_hook"
+        ),
+        (
+            "runem: hooks: registered hook for 'HookName.ON_EXIT', have 2: echo "
+            '"mock_hook_function_bash called aok"'
+        ),
+        "runem: hooks: invoking 2 hooks for 'HookName.ON_EXIT'",
+        "runem: START: 'HookName.ON_EXIT'",
+        "runem: job: running: 'HookName.ON_EXIT'",
+        "mock_hook_function_function called aok",
+        "runem: job: DONE: 'HookName.ON_EXIT': 0:00:00",
+        "runem: START: 'HookName.ON_EXIT'",
+        "runem: job: running: 'HookName.ON_EXIT'",
+        'runem: running: start: HookName.ON_EXIT: echo "mock_hook_function_bash '
+        'called aok"',
+        'runem: HookName.ON_EXIT: "mock_hook_function_bash called aok"',
+        "",
+        'runem: running: done: HookName.ON_EXIT: echo "mock_hook_function_bash called '
+        'aok"',
+        "runem: job: DONE: 'HookName.ON_EXIT': 0:00:00",
+        "runem: hooks: done invoking 'HookName.ON_EXIT'",
+        "",
+    ]
+
+
+def test_register_non_existent_hook(hook_man: HookManager) -> None:
+    """Test error handling for registering a non-existent hook."""
+    with pytest.raises(ValueError) as e:
+        hook_man.register_hook(
+            "non_existent_hook", mock_hook_function, verbose=False  # type: ignore
+        )
+    assert "Hook non_existent_hook does not exist" in str(e.value)
+
+
+def test_deregister_non_existent_function(hook_man: HookManager) -> None:
+    """Test error handling for deregistering a non-existent function."""
+    not_registered: HookConfig = {
+        "addr": {"file": __file__, "function": "_dummy_hook"},
+        "hook_name": HookName("on-exit"),
+    }
+
+    with pytest.raises(ValueError) as e:
+        hook_man.deregister_hook(HookName.ON_EXIT, not_registered, verbose=False)
+    assert "Function not found in hook" in str(e.value)

--- a/tests/test_job_filter.py
+++ b/tests/test_job_filter.py
@@ -4,7 +4,7 @@ import typing
 from argparse import Namespace
 from collections import defaultdict
 from contextlib import redirect_stdout
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -50,6 +50,7 @@ def test_runem_job_filters_work_with_no_tags(verbosity: bool) -> None:
             #     "regex": ".*1.txt",  # should match just one file
             # }
         },
+        hook_manager=MagicMock(),
         jobs=expected_jobs,
         all_job_names=set(("dummy job label",)),
         all_job_phases=set(("dummy phase 1",)),

--- a/tests/test_job_wrapper.py
+++ b/tests/test_job_wrapper.py
@@ -48,7 +48,7 @@ def test_get_job_wrapper_python_wrapper_job(mock_get_job_wrapper_py_func: Mock) 
 def test_get_job_wrapper_simple_command_job(mock_get_job_wrapper_py_func: Mock) -> None:
     """Checks that the job_runner_simple_command is returned for 'command' jobs."""
     job_config: JobConfig = {
-        "command": "echo 'testing exec",
+        "command": "echo 'testing exec'",
     }
     func_obj: JobFunction = get_job_wrapper(
         job_config, cfg_filepath=pathlib.Path(__file__)

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -84,7 +84,7 @@ def test_runem_basic() -> None:
 
 
 @patch(
-    "runem.runem.load_config",
+    "runem.runem.load_project_config",
 )
 @patch(
     "runem.runem.find_files",
@@ -127,7 +127,7 @@ def test_runem_basic_with_config(
 
 
 @patch(
-    "runem.runem.load_config",
+    "runem.runem.load_project_config",
 )
 @patch(
     "runem.runem.find_files",
@@ -173,7 +173,7 @@ MOCK_JOB_EXECUTE_INNER_RET: typing.Tuple[JobTiming, JobReturn] = (
 
 
 @patch(
-    "runem.runem.load_config",
+    "runem.runem.load_project_config",
 )
 @patch(
     "runem.runem.find_files",

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -417,6 +417,10 @@ def test_runem_with_full_config(verbosity: bool) -> None:
                 "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                 "'dummy phase 1'"
             ),
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             (
@@ -466,6 +470,10 @@ def test_runem_with_full_config_verbose() -> None:
             "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
             "'dummy phase 1'"
         ),
+        "runem: hooks: loading user hooks from 'local-user-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+        "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
         "runem: hooks: initialising 2 hooks",
         "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
         (
@@ -514,6 +522,10 @@ def test_runem_with_single_phase() -> None:
             "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
             "'dummy phase 1'"
         ),
+        "runem: hooks: loading user hooks from 'local-user-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+        "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
         "runem: hooks: initialising 2 hooks",
         "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
         (
@@ -560,6 +572,10 @@ def test_runem_with_single_phase_verbose() -> None:
             "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
             "'dummy phase 1'"
         ),
+        "runem: hooks: loading user hooks from 'local-user-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+        "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
         "runem: hooks: initialising 2 hooks",
         "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
         (
@@ -604,11 +620,12 @@ def _remove_first_line_and_split_along_whitespace(
     # contexts:
     # usage: __main__.py [-h] [--jobs JOBS [JOBS ...]]
     # usage: -c [-h] [--jobs JOBS [JOBS ...]]
-    index_of_usage_lines: typing.Tuple[int, ...] = (1, 6)
+    index_of_usage_lines: typing.Tuple[int, ...] = (1, 9)
     usage_line: typing.Optional[str] = None
     for index_of_usage_line in index_of_usage_lines:  # pragma: no cover
-        usage_line = lines[index_of_usage_line]
-        if "usage:" in usage_line:
+        usage_line_candidate: str = lines[index_of_usage_line]
+        if "usage:" in usage_line_candidate:
+            usage_line = usage_line_candidate
             break
     if usage_line is None:  # pragma: no cover
         pprint(lines)
@@ -725,6 +742,10 @@ def test_runem_version(switch_to_test: str, verbosity: bool) -> None:
     expected_version_output: typing.List[str] = [version_file.read_text().strip(), ""]
     if verbosity:
         expected_version_output = [
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             "runem: hooks: registered hook for 'HookName.ON_EXIT', have 1: echo 'mock "
@@ -764,6 +785,10 @@ def test_runem_bad_validate_switch_jobs(switch_to_test: str) -> None:
             "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
             "'dummy phase 1'"
         ),
+        "runem: hooks: loading user hooks from 'local-user-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+        "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
         "runem: hooks: initialising 2 hooks",
         "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
         (
@@ -811,6 +836,10 @@ def test_runem_bad_validate_switch_tags(switch_to_test: str) -> None:
             "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
             "'dummy phase 1'"
         ),
+        "runem: hooks: loading user hooks from 'local-user-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+        "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
         "runem: hooks: initialising 2 hooks",
         "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
         (
@@ -858,6 +887,10 @@ def test_runem_bad_validate_switch_phases(switch_to_test: str) -> None:
             "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
             "'dummy phase 1'"
         ),
+        "runem: hooks: loading user hooks from 'local-user-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+        "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+        "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
         "runem: hooks: initialising 2 hooks",
         "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
         (
@@ -908,6 +941,10 @@ def test_runem_job_filters_work(verbosity: bool) -> None:
                 "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                 "'dummy phase 1'"
             ),
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             (
@@ -952,6 +989,10 @@ def test_runem_job_filters_work(verbosity: bool) -> None:
                 "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                 "'dummy phase 1'"
             ),
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             (
@@ -1026,6 +1067,10 @@ def test_runem_tag_filters_work(verbosity: bool) -> None:
                 "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                 "'dummy phase 1'"
             ),
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             (
@@ -1059,6 +1104,10 @@ def test_runem_tag_filters_work(verbosity: bool) -> None:
                 "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                 "'dummy phase 1'"
             ),
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             (
@@ -1135,6 +1184,10 @@ def test_runem_tag_out_filters_work(verbosity: bool, one_liner: bool) -> None:
                     "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                     "'dummy phase 1'"
                 ),
+                "runem: hooks: loading user hooks from 'local-user-config.yml'",
+                "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+                "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+                "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
                 "runem: hooks: initialising 2 hooks",
                 "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
                 (
@@ -1174,6 +1227,10 @@ def test_runem_tag_out_filters_work(verbosity: bool, one_liner: bool) -> None:
                     "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                     "'dummy phase 1'"
                 ),
+                "runem: hooks: loading user hooks from 'local-user-config.yml'",
+                "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+                "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+                "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
                 "runem: hooks: initialising 2 hooks",
                 "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
                 (
@@ -1207,6 +1264,10 @@ def test_runem_tag_out_filters_work(verbosity: bool, one_liner: bool) -> None:
         if verbosity:
             # no-one-liner + verbosity
             assert runem_stdout == [
+                "runem: hooks: loading user hooks from 'local-user-config.yml'",
+                "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+                "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+                "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
                 "runem: hooks: initialising 2 hooks",
                 "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
                 (
@@ -1239,6 +1300,10 @@ def test_runem_tag_out_filters_work(verbosity: bool, one_liner: bool) -> None:
         else:
             # no-one-liner + no-verbosity
             assert runem_stdout == [
+                "runem: hooks: loading user hooks from 'local-user-config.yml'",
+                "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+                "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+                "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
                 "runem: hooks: initialising 2 hooks",
                 "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
                 (
@@ -1306,6 +1371,10 @@ def test_runem_tag_out_filters_work_all_tags(verbosity: bool) -> None:
 
     if verbosity:
         assert runem_stdout == [
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             (
@@ -1383,6 +1452,10 @@ def test_runem_phase_filters_work(verbosity: bool) -> None:
                 "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                 "'dummy phase 1'"
             ),
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             (
@@ -1411,6 +1484,10 @@ def test_runem_phase_filters_work(verbosity: bool) -> None:
                 "runem: WARNING: no phase found for 'echo \"hello world!\"', using "
                 "'dummy phase 1'"
             ),
+            "runem: hooks: loading user hooks from 'local-user-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
+            "runem: hooks: loading user hooks from 'local-user-home-dir-config.yml'",
+            "runem: hooks:\tadded 1 user hooks for 'HookName.ON_EXIT'",
             "runem: hooks: initialising 2 hooks",
             "runem: hooks:\tinitialising 2 hooks for 'HookName.ON_EXIT'",
             (

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -652,7 +652,8 @@ def test_runem_help() -> None:
         runem_stdout,
         error_raised,
     ) = _run_full_config_runem(  # pylint: disable=no-value-for-parameter
-        runem_cli_switches=runem_cli_switches
+        runem_cli_switches=runem_cli_switches,
+        add_verbose_switch=False,
     )
     assert runem_stdout
     assert error_raised


### PR DESCRIPTION
### Summary :memo:

This adds support for user-specific callbacks when running runem, initially only ON_EXIT.

### Details

The main use-case for this is to be able to get osx to `say "done"` and similar.

Eventually we will:
- add more detailed support for timing so run-times can be graphed
- add other hooks, e.g. bootstrapping support for distributed running
- add error-hooks for when tests fail and the code can be auto-fixed using AI or similar
- etc. loads of possibilities
