### PR TITLE
Feat/git fast files

### DIFF
--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -22,7 +22,12 @@ def parse_args(
 
     Returns the parsed args, the jobs_names_to_run, job_phases_to_run, job_tags_to_run
     """
-    parser = argparse.ArgumentParser(description="Runs the Lursight Lang test-suite")
+    parser = argparse.ArgumentParser(
+        add_help=False, description="Runs the Lursight Lang test-suite"
+    )
+    parser.add_argument(
+        "-H", "--help", action="help", help="show this help message and exit"
+    )
 
     job_group = parser.add_argument_group("jobs")
     all_job_names: JobNames = set(name for name in config_metadata.all_job_names)

--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -118,6 +118,26 @@ def parse_args(
     )
 
     parser.add_argument(
+        "-f",
+        "--modified-files-only",
+        dest="check_modified_files_only",
+        help="only use files that have changed",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        required=False,
+    )
+
+    parser.add_argument(
+        "-h",
+        "--git-head-files-only",
+        dest="check_head_files_only",
+        help="fast run of files",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        required=False,
+    )
+
+    parser.add_argument(
         "--procs",
         "-j",
         # "-n",

--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -6,7 +6,7 @@ import typing
 
 from runem.config_metadata import ConfigMetadata
 from runem.informative_dict import InformativeDict
-from runem.log import log
+from runem.log import error, log
 from runem.runem_version import get_runem_version
 from runem.types import JobNames, OptionConfig, OptionsWritable
 from runem.utils import printable_set
@@ -206,9 +206,9 @@ def _validate_filters(
     for name, name_list in (("--jobs", args.jobs), ("--not-jobs", args.jobs_excluded)):
         for job_name in name_list:
             if job_name not in config_metadata.all_job_names:
-                log(
+                error(
                     (
-                        f"ERROR: invalid job-name '{job_name}' for {name}, "
+                        f"invalid job-name '{job_name}' for {name}, "
                         f"choose from one of {printable_set(config_metadata.all_job_names)}"
                     )
                 )
@@ -218,9 +218,9 @@ def _validate_filters(
     for name, tag_list in (("--tags", args.tags), ("--not-tags", args.tags_excluded)):
         for tag in tag_list:
             if tag not in config_metadata.all_job_tags:
-                log(
+                error(
                     (
-                        f"ERROR: invalid tag '{tag}' for {name}, "
+                        f"invalid tag '{tag}' for {name}, "
                         f"choose from one of {printable_set(config_metadata.all_job_tags)}"
                     )
                 )
@@ -233,9 +233,9 @@ def _validate_filters(
     ):
         for phase in phase_list:
             if phase not in config_metadata.all_job_phases:
-                log(
+                error(
                     (
-                        f"ERROR: invalid phase '{phase}' for {name}, "
+                        f"invalid phase '{phase}' for {name}, "
                         f"choose from one of {printable_set(config_metadata.all_job_phases)}"
                     )
                 )

--- a/runem/config.py
+++ b/runem/config.py
@@ -5,7 +5,7 @@ import typing
 import yaml
 from packaging.version import Version
 
-from runem.log import log
+from runem.log import error, log
 from runem.runem_version import get_runem_version
 from runem.types import Config, GlobalConfig, GlobalSerialisedConfig, UserConfigMetadata
 
@@ -61,7 +61,7 @@ def _find_project_cfg() -> pathlib.Path:
         return cfg_candidate
 
     # error out and exit as we currently require the cfg file as it lists jobs.
-    log(f"ERROR: Config not found! Looked from {start_dirs}")
+    error(f"Config not found! Looked from {start_dirs}")
     sys.exit(1)
 
 

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -9,7 +9,7 @@ from runem.config_metadata import ConfigMetadata
 from runem.hook_manager import HookManager
 from runem.job import Job
 from runem.job_wrapper import get_job_wrapper
-from runem.log import log
+from runem.log import error, log, warn
 from runem.types import (
     Config,
     ConfigNodes,
@@ -105,8 +105,10 @@ def _parse_job(  # noqa: C901
     job_name: str = Job.get_job_name(job)
     job_names_used = job_name in in_out_job_names
     if job_names_used:
-        log("ERROR: duplicate job label!")
-        log(f"\t'{job['label']}' is used twice or more in {str(cfg_filepath)}")
+        error(
+            "duplicate job label!"
+            f"\t'{job['label']}' is used twice or more in {str(cfg_filepath)}"
+        )
         sys.exit(1)
 
     try:
@@ -123,15 +125,13 @@ def _parse_job(  # noqa: C901
         try:
             fallback_phase = phase_order[0]
             if warn_missing_phase:
-                log(
-                    f"WARNING: no phase found for '{job_name}', using '{fallback_phase}'"
-                )
+                warn(f"no phase found for '{job_name}', using '{fallback_phase}'")
         except IndexError:
             fallback_phase = "<NO PHASES FOUND>"
             if warn_missing_phase:
-                log(
+                warn(
                     (
-                        f"WARNING: no phases found for '{job_name}', "
+                        f"no phases found for '{job_name}', "
                         f"or in '{str(cfg_filepath)}', "
                         f"using '{fallback_phase}'"
                     )
@@ -287,9 +287,7 @@ def parse_config(
 
     if not phase_order:
         if not hooks_only:
-            log(
-                "WARNING: phase ordering not configured! Runs will be non-deterministic!"
-            )
+            warn("phase ordering not configured! Runs will be non-deterministic!")
             phase_order = tuple(job_phases)
 
     # now parse out the job_configs

--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -9,7 +9,7 @@ from runem.config_metadata import ConfigMetadata
 from runem.informative_dict import ReadOnlyInformativeDict
 from runem.job import Job
 from runem.job_wrapper import get_job_wrapper
-from runem.log import log
+from runem.log import error, log
 from runem.types import (
     FilePathListLookup,
     JobConfig,
@@ -92,7 +92,7 @@ def job_execute_inner(
     except BaseException:  # pylint: disable=broad-exception-caught
         # log that we hit an error on this job and re-raise
         log(decorate=False)
-        log(f"job: ERROR: job '{Job.get_job_name(job_config)}' failed to complete!")
+        error(f"job: job '{Job.get_job_name(job_config)}' failed to complete!")
         # re-raise
         raise
 

--- a/runem/log.py
+++ b/runem/log.py
@@ -14,3 +14,11 @@ def log(msg: str = "", decorate: bool = True, end: typing.Optional[str] = None) 
     # print in a blocking manner, waiting for system resources to free up if a
     # runem job is contending on stdout or similar.
     blocking_print(msg, end=end)
+
+
+def warn(msg: str) -> None:
+    log(f"WARNING: {msg}")
+
+
+def error(msg: str) -> None:
+    log(f"ERROR: {msg}")

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -41,7 +41,7 @@ from runem.files import find_files
 from runem.job import Job
 from runem.job_execute import job_execute
 from runem.job_filter import filter_jobs
-from runem.log import error, log
+from runem.log import error, log, warn
 from runem.report import report_on_run
 from runem.types import (
     Config,
@@ -290,7 +290,10 @@ def _main(
     os.chdir(config_metadata.cfg_filepath.parent)
 
     file_lists: FilePathListLookup = find_files(config_metadata)
-    assert file_lists
+    if not file_lists:
+        warn("no files found")
+        return (config_metadata, {}, None)
+
     if config_metadata.args.verbose:
         log(f"found {len(file_lists)} batches, ", end="")
         for tag in sorted(file_lists.keys()):

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -41,7 +41,7 @@ from runem.files import find_files
 from runem.job import Job
 from runem.job_execute import job_execute
 from runem.job_filter import filter_jobs
-from runem.log import log
+from runem.log import error, log
 from runem.report import report_on_run
 from runem.types import (
     Config,
@@ -267,7 +267,7 @@ def _process_jobs_by_phase(
         )
         if failure_exception is not None:
             if config_metadata.args.verbose:
-                log(f"ERROR: running phase {phase}: aborting run")
+                error(f"running phase {phase}: aborting run")
             return failure_exception
 
     # ALl phases completed aok.

--- a/tests/data/help_output.3.10.txt
+++ b/tests/data/help_output.3.10.txt
@@ -8,6 +8,8 @@ usage: -c [-H] [--jobs JOBS [JOBS ...]]
           [--dummy-option-1---complete-option]
           [--no-dummy-option-1---complete-option] [--dummy-option-2---minimal]
           [--no-dummy-option-2---minimal] [--call-graphs | --no-call-graphs]
+          [-f | --modified-files-only | --no-modified-files-only]
+          [-h | --git-head-files-only | --no-git-head-files-only]
           [--procs PROCS] [--root ROOT_DIR] [--spinner | --no-spinner]
           [--verbose | --no-verbose] [--version | --no-version | -v]
 
@@ -16,6 +18,10 @@ Runs the Lursight Lang test-suite
 [TEST_REPLACED_OPTION_HEADER]
   -H, --help            show this help message and exit
   --call-graphs, --no-call-graphs
+  -f, --modified-files-only, --no-modified-files-only
+                        only use files that have changed (default: False)
+  -h, --git-head-files-only, --no-git-head-files-only
+                        fast run of files (default: False)
   --procs PROCS, -j PROCS
                         the number of concurrent test jobs to run, -1 runs all
                         test jobs at the same time ([TEST_REPLACED_CORES] cores available)

--- a/tests/data/help_output.3.10.txt
+++ b/tests/data/help_output.3.10.txt
@@ -1,5 +1,5 @@
 runem: WARNING: no phase found for 'echo "hello world!"', using 'dummy phase 1'
-usage: -c [-h] [--jobs JOBS [JOBS ...]]
+usage: -c [-H] [--jobs JOBS [JOBS ...]]
           [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]]
           [--phases PHASES [PHASES ...]]
           [--not-phases PHASES_EXCLUDED [PHASES_EXCLUDED ...]]
@@ -14,7 +14,7 @@ usage: -c [-h] [--jobs JOBS [JOBS ...]]
 Runs the Lursight Lang test-suite
 
 [TEST_REPLACED_OPTION_HEADER]
-  -h, --help            show this help message and exit
+  -H, --help            show this help message and exit
   --call-graphs, --no-call-graphs
   --procs PROCS, -j PROCS
                         the number of concurrent test jobs to run, -1 runs all

--- a/tests/data/help_output.3.11.txt
+++ b/tests/data/help_output.3.11.txt
@@ -8,6 +8,8 @@ usage: -c [-H] [--jobs JOBS [JOBS ...]]
           [--dummy-option-1---complete-option]
           [--no-dummy-option-1---complete-option] [--dummy-option-2---minimal]
           [--no-dummy-option-2---minimal] [--call-graphs | --no-call-graphs]
+          [-f | --modified-files-only | --no-modified-files-only]
+          [-h | --git-head-files-only | --no-git-head-files-only]
           [--procs PROCS] [--root ROOT_DIR] [--spinner | --no-spinner]
           [--verbose | --no-verbose] [--version | --no-version | -v]
 
@@ -16,6 +18,10 @@ Runs the Lursight Lang test-suite
 [TEST_REPLACED_OPTION_HEADER]
   -H, --help            show this help message and exit
   --call-graphs, --no-call-graphs
+  -f, --modified-files-only, --no-modified-files-only
+                        only use files that have changed
+  -h, --git-head-files-only, --no-git-head-files-only
+                        fast run of files
   --procs PROCS, -j PROCS
                         the number of concurrent test jobs to run, -1 runs all
                         test jobs at the same time ([TEST_REPLACED_CORES] cores available)

--- a/tests/data/help_output.3.11.txt
+++ b/tests/data/help_output.3.11.txt
@@ -1,5 +1,5 @@
 runem: WARNING: no phase found for 'echo "hello world!"', using 'dummy phase 1'
-usage: -c [-h] [--jobs JOBS [JOBS ...]]
+usage: -c [-H] [--jobs JOBS [JOBS ...]]
           [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED ...]]
           [--phases PHASES [PHASES ...]]
           [--not-phases PHASES_EXCLUDED [PHASES_EXCLUDED ...]]
@@ -14,7 +14,7 @@ usage: -c [-h] [--jobs JOBS [JOBS ...]]
 Runs the Lursight Lang test-suite
 
 [TEST_REPLACED_OPTION_HEADER]
-  -h, --help            show this help message and exit
+  -H, --help            show this help message and exit
   --call-graphs, --no-call-graphs
   --procs PROCS, -j PROCS
                         the number of concurrent test jobs to run, -1 runs all

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,17 +1,20 @@
 import pathlib
+from argparse import Namespace
 from collections import defaultdict
+from typing import List
 from unittest.mock import MagicMock, Mock, patch
+
+import pytest
 
 from runem.config_metadata import ConfigMetadata
 from runem.files import find_files
+from runem.informative_dict import InformativeDict
 from runem.types import FilePathListLookup
 
 
-@patch(
-    "runem.files.subprocess_check_output",
-    return_value=str.encode("test_file_1.txt\ntest_file_2.txt"),
-)
-def test_find_files_basic(mock_subprocess_check_output: Mock) -> None:
+def _prep_config(
+    check_modified_files_only: bool, check_head_files_only: bool
+) -> ConfigMetadata:
     config_metadata: ConfigMetadata = ConfigMetadata(
         cfg_filepath=pathlib.Path(__file__),
         phases=("dummy phase 1",),
@@ -28,10 +31,57 @@ def test_find_files_basic(mock_subprocess_check_output: Mock) -> None:
         all_job_phases=set(),
         all_job_tags=set(),
     )
+    config_metadata.set_cli_data(
+        args=Namespace(
+            check_modified_files_only=check_modified_files_only,
+            check_head_files_only=check_head_files_only,
+        ),
+        jobs_to_run=set(),  # JobNames,
+        phases_to_run=set(),  # JobPhases,
+        tags_to_run=set(),  # ignored JobTags,
+        tags_to_avoid=set(),  # ignored  JobTags,
+        options=InformativeDict({}),  # Options,
+    )
+
+    return config_metadata
+
+
+@pytest.mark.parametrize(
+    "check_head_files_only",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "check_modified_files_only",
+    [
+        True,
+        False,
+    ],
+)
+@patch(
+    "runem.files.subprocess_check_output",
+)
+def test_find_files_basic(
+    mock_subprocess_check_output: Mock,
+    check_modified_files_only: bool,
+    check_head_files_only: bool,
+    tmp_path: pathlib.Path,
+) -> None:
+    file_strings: List[str] = []
+    for file_str in ("test_file_1.txt", "test_file_2.txt"):
+        test_file: pathlib.Path = tmp_path / file_str
+        test_file.write_text("")  # write some empty string aka 'touch' the file
+        file_strings.append(str(test_file))
+    mock_subprocess_check_output.return_value = str.encode("\n".join(file_strings))
+
+    config_metadata = _prep_config(
+        check_modified_files_only=check_modified_files_only,
+        check_head_files_only=check_head_files_only,
+    )
     results: FilePathListLookup = find_files(config_metadata)
-    assert results == {
-        "dummy tag": [
-            "test_file_1.txt",
-        ]
-    }
     mock_subprocess_check_output.assert_called_once()
+    assert results == {
+        "dummy tag": [file_strings[0]]  # we filter in only the *1* files.
+    }

--- a/tests/test_job_execute.py
+++ b/tests/test_job_execute.py
@@ -394,7 +394,7 @@ def test_job_execute_with_raising_func() -> None:
         "runem: START: 'intentionally throwing'",
         "runem: job: running: 'intentionally throwing'",
         "",
-        "runem: job: ERROR: job 'intentionally throwing' failed to complete!",
+        "runem: ERROR: job: job 'intentionally throwing' failed to complete!",
         "",
     ]
 


### PR DESCRIPTION
### Summary :memo:

Adds support for faster runs by limiting runs to only changed or HEAD files.

### Details
We add two switches
- `-f`/`--modified-files-only` enables the "fast" option, which is to say we limit tests to files which are changed
- `-h`/`--git-head-files-only` enables the "head" option, which is to say we limit tests to files which were changed in the latest HEAD commit

The latter means we remove -h as a alias for `--help` replacing it with `-H` (capital 'h').

We also add `warn` and `error` logging types.
