### PR TITLE
Feat/allow additional files to be checked

### DIFF
--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -136,6 +136,17 @@ def parse_args(
         default=False,
         required=False,
     )
+    parser.add_argument(
+        "--always-files",
+        dest="always_files",
+        help=(
+            "list of paths/files to always check (overriding -f/-h), if the path "
+            "matches the filter regex and if file-paths exist"
+        ),
+        nargs="+",
+        default=None,
+        required=False,
+    )
 
     parser.add_argument(
         "--procs",

--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -149,6 +149,18 @@ def parse_args(
     )
 
     parser.add_argument(
+        "--git-files-since-branch",
+        dest="git_since_branch",
+        help=(
+            "Get the list of paths/files changed between a branch, e.g., since "
+            "'origin/main'. Useful for checking files changed before pushing."
+        ),
+        default=None,  # Default to None if no branch is specified
+        required=False,  # Not required, users may not want to specify a branch
+        type=str,  # Accepts a string input representing the branch name
+    )
+
+    parser.add_argument(
         "--procs",
         "-j",
         # "-n",

--- a/runem/files.py
+++ b/runem/files.py
@@ -74,6 +74,16 @@ def find_files(config_metadata: ConfigMetadata) -> FilePathListLookup:
             .decode("utf-8")
             .splitlines()
         )
+
+    if config_metadata.args.always_files is not None:
+        # a poor-man's version of adding path-regex's
+        existent_files = [
+            filepath
+            for filepath in config_metadata.args.always_files
+            if Path(filepath).exists()
+        ]
+        file_paths.extend(existent_files)
+
     _bucket_file_by_tag(
         file_paths,
         config_metadata,

--- a/tests/data/help_output.3.10.txt
+++ b/tests/data/help_output.3.10.txt
@@ -6,7 +6,8 @@ usage: -c [-H] [--jobs JOBS [JOBS ...]] [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED
           [--dummy-option-2---minimal] [--no-dummy-option-2---minimal]
           [--call-graphs | --no-call-graphs] [-f | --modified-files | --no-modified-files]
           [-h | --git-head-files | --no-git-head-files]
-          [--always-files ALWAYS_FILES [ALWAYS_FILES ...]] [--procs PROCS] [--root ROOT_DIR]
+          [--always-files ALWAYS_FILES [ALWAYS_FILES ...]]
+          [--git-files-since-branch GIT_SINCE_BRANCH] [--procs PROCS] [--root ROOT_DIR]
           [--root-show | --no-root-show] [--spinner | --no-spinner] [--verbose | --no-verbose]
           [--version | --no-version | -v]
 
@@ -22,6 +23,9 @@ Runs the Lursight Lang test-suite
   --always-files ALWAYS_FILES [ALWAYS_FILES ...]
                         list of paths/files to always check (overriding -f/-h), if the path
                         matches the filter regex and if file-paths exist
+  --git-files-since-branch GIT_SINCE_BRANCH
+                        Get the list of paths/files changed between a branch, e.g., since
+                        'origin/main'. Useful for checking files changed before pushing.
   --procs PROCS, -j PROCS
                         the number of concurrent test jobs to run, -1 runs all test jobs at the
                         same time ([TEST_REPLACED_CORES] cores available)

--- a/tests/data/help_output.3.10.txt
+++ b/tests/data/help_output.3.10.txt
@@ -5,7 +5,8 @@ usage: -c [-H] [--jobs JOBS [JOBS ...]] [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED
           [--dummy-option-1---complete-option] [--no-dummy-option-1---complete-option]
           [--dummy-option-2---minimal] [--no-dummy-option-2---minimal]
           [--call-graphs | --no-call-graphs] [-f | --modified-files | --no-modified-files]
-          [-h | --git-head-files | --no-git-head-files] [--procs PROCS] [--root ROOT_DIR]
+          [-h | --git-head-files | --no-git-head-files]
+          [--always-files ALWAYS_FILES [ALWAYS_FILES ...]] [--procs PROCS] [--root ROOT_DIR]
           [--root-show | --no-root-show] [--spinner | --no-spinner] [--verbose | --no-verbose]
           [--version | --no-version | -v]
 
@@ -18,6 +19,9 @@ Runs the Lursight Lang test-suite
                         only use files that have changed (default: False)
   -h, --git-head-files, --no-git-head-files
                         fast run of files (default: False)
+  --always-files ALWAYS_FILES [ALWAYS_FILES ...]
+                        list of paths/files to always check (overriding -f/-h), if the path
+                        matches the filter regex and if file-paths exist
   --procs PROCS, -j PROCS
                         the number of concurrent test jobs to run, -1 runs all test jobs at the
                         same time ([TEST_REPLACED_CORES] cores available)

--- a/tests/data/help_output.3.11.txt
+++ b/tests/data/help_output.3.11.txt
@@ -5,7 +5,8 @@ usage: -c [-H] [--jobs JOBS [JOBS ...]] [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED
           [--dummy-option-1---complete-option] [--no-dummy-option-1---complete-option]
           [--dummy-option-2---minimal] [--no-dummy-option-2---minimal]
           [--call-graphs | --no-call-graphs] [-f | --modified-files | --no-modified-files]
-          [-h | --git-head-files | --no-git-head-files] [--procs PROCS] [--root ROOT_DIR]
+          [-h | --git-head-files | --no-git-head-files]
+          [--always-files ALWAYS_FILES [ALWAYS_FILES ...]] [--procs PROCS] [--root ROOT_DIR]
           [--root-show | --no-root-show] [--spinner | --no-spinner] [--verbose | --no-verbose]
           [--version | --no-version | -v]
 
@@ -18,6 +19,9 @@ Runs the Lursight Lang test-suite
                         only use files that have changed
   -h, --git-head-files, --no-git-head-files
                         fast run of files
+  --always-files ALWAYS_FILES [ALWAYS_FILES ...]
+                        list of paths/files to always check (overriding -f/-h), if the path
+                        matches the filter regex and if file-paths exist
   --procs PROCS, -j PROCS
                         the number of concurrent test jobs to run, -1 runs all test jobs at the
                         same time ([TEST_REPLACED_CORES] cores available)

--- a/tests/data/help_output.3.11.txt
+++ b/tests/data/help_output.3.11.txt
@@ -6,7 +6,8 @@ usage: -c [-H] [--jobs JOBS [JOBS ...]] [--not-jobs JOBS_EXCLUDED [JOBS_EXCLUDED
           [--dummy-option-2---minimal] [--no-dummy-option-2---minimal]
           [--call-graphs | --no-call-graphs] [-f | --modified-files | --no-modified-files]
           [-h | --git-head-files | --no-git-head-files]
-          [--always-files ALWAYS_FILES [ALWAYS_FILES ...]] [--procs PROCS] [--root ROOT_DIR]
+          [--always-files ALWAYS_FILES [ALWAYS_FILES ...]]
+          [--git-files-since-branch GIT_SINCE_BRANCH] [--procs PROCS] [--root ROOT_DIR]
           [--root-show | --no-root-show] [--spinner | --no-spinner] [--verbose | --no-verbose]
           [--version | --no-version | -v]
 
@@ -22,6 +23,9 @@ Runs the Lursight Lang test-suite
   --always-files ALWAYS_FILES [ALWAYS_FILES ...]
                         list of paths/files to always check (overriding -f/-h), if the path
                         matches the filter regex and if file-paths exist
+  --git-files-since-branch GIT_SINCE_BRANCH
+                        Get the list of paths/files changed between a branch, e.g., since
+                        'origin/main'. Useful for checking files changed before pushing.
   --procs PROCS, -j PROCS
                         the number of concurrent test jobs to run, -1 runs all test jobs at the
                         same time ([TEST_REPLACED_CORES] cores available)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -16,7 +16,8 @@ def _prep_config(
     tmp_path: pathlib.Path,
     check_modified_files: bool,
     check_head_files: bool,
-    always_files: Optional[List[str]] = None,
+    always_files: Optional[List[str]],
+    git_since_branch: Optional[str],
 ) -> ConfigMetadata:
     config_metadata: ConfigMetadata = ConfigMetadata(
         cfg_filepath=tmp_path / ".runem.yml.no-exist",  # only the path is used
@@ -39,6 +40,7 @@ def _prep_config(
             check_modified_files=check_modified_files,
             check_head_files=check_head_files,
             always_files=always_files,
+            git_since_branch=git_since_branch,
         ),
         jobs_to_run=set(),  # JobNames,
         phases_to_run=set(),  # JobPhases,
@@ -104,6 +106,7 @@ def test_find_files_basic(
         check_modified_files=check_modified_files,
         check_head_files=check_head_files,
         always_files=created_always_files,
+        git_since_branch=None,
     )
     results: FilePathListLookup = find_files(config_metadata)
     if check_modified_files and check_head_files:
@@ -115,6 +118,48 @@ def test_find_files_basic(
         }
     elif check_modified_files:
         assert mock_subprocess_check_output.call_count == 2, "twice for modified"
+        assert results == {
+            "dummy tag": [file_strings[0]]  # we filter in only the *1* files.
+        }
+    else:
+        assert mock_subprocess_check_output.call_count == 1, "once for git ls-files"
+        assert results == {
+            "dummy tag": [file_strings[0]]  # we filter in only the *1* files.
+        }
+
+
+@pytest.mark.parametrize(
+    "git_since_branch",
+    [
+        None,
+        "/dummy/branch/name",
+    ],
+)
+@patch(
+    "runem.files.subprocess_check_output",
+)
+def test_find_files_git_since_branch(
+    mock_subprocess_check_output: Mock,
+    git_since_branch: Optional[str],
+    tmp_path: pathlib.Path,
+) -> None:
+    file_strings: List[str] = []
+    for file_str in ("test_file_1.txt", "test_file_2.txt"):
+        test_file: pathlib.Path = tmp_path / file_str
+        test_file.touch()  # write some empty string aka 'touch' the file
+        file_strings.append(str(test_file))
+    mock_subprocess_check_output.return_value = str.encode("\n".join(file_strings))
+
+    config_metadata = _prep_config(
+        tmp_path,
+        check_modified_files=False,
+        check_head_files=False,
+        always_files=None,
+        git_since_branch=git_since_branch,
+    )
+    results: FilePathListLookup = find_files(config_metadata)
+    if git_since_branch is None:
+        assert mock_subprocess_check_output.call_count == 1, "once for git ls-files"
         assert results == {
             "dummy tag": [file_strings[0]]  # we filter in only the *1* files.
         }


### PR DESCRIPTION
### Summary :memo:

Add `--always-files` and `--git-files-since-branch` options, allowing files to be force-considered (ignoring filters) and allowing all files between two branches to be additionally considered (respectively).

Also adds utils for modifying the help-tests, so we can more easily track _unintentional_ changes down the line.

### Details

#### `[--always-files ALWAYS_FILES [ALWAYS_FILES ...]]` 

Sometimes you want to be able to force a file to be included in a test run, despite other filters you may have in place. For example

- to ensure a critical file you want to ensure isn't impacted by other changes
- to add a dependent file that may be impacted by other changes
- files that are untracked by git

#### `[--git-files-since-branch GIT_SINCE_BRANCH]`

Sometimes you want to filter files to consider only changed files since a branch and not just files that changed in the HEAD or in the stage/unstaged arena. For example:

- when pushing changes you might want to only check the files that changed on the branch, and let CI/CD take care of the reset.
- during an `--exec` rebase, you want to quickly test that the impact of each commit on all of the files that came before the HEAD commit, if the work is cummulative in nature.
