### PR TITLE
chore(release): use tox on 'make release'

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,7 +11,7 @@ if [[ -z "${TAG}" ]]; then
     exit 5
 fi
 echo "Will tag to version ${TAG} after tests"
-python3 -m runem.runem --check
+tox # run all test across all supported python versions
 echo "${TAG}" > runem/VERSION
 ${ENV_PREFIX}gitchangelog > HISTORY.md
 git add runem/VERSION HISTORY.md


### PR DESCRIPTION
### Summary :memo:

chore(release): use tox on 'make release'

### Details

This will run the checks across the range of supported python versions, hopefully making everything more solid.

TODO: move all of this to github-actions, including the tagging, instead
      of just releasing based on tags