### PR TITLE
Chore/test improvements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 # This requirements are for development and testing only, not for production.
 black==24.3.0
-coverage==7.4.4
+coverage==7.5
 docformatter==1.7.5
 flake8-bugbear==24.2.6
 flake8==7.0.0
@@ -11,10 +11,10 @@ mypy==1.9.0
 pydocstyle==6.3.0
 pylint==3.1.0
 pylama==8.4.1
-pytest-cov==4.1.0
+pytest-cov==6.0.0
 pytest-profiling==1.7.0
-pytest-xdist==3.5.0
-pytest==8.1.1
+pytest-xdist==3.6.1
+pytest==8.3.3
 setuptools
 termplotlib==0.3.9
 tox

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 # This requirements are for development and testing only, not for production.
-black==24.3.0
+black==24.10.0
 coverage==7.5
 docformatter==1.7.5
 flake8-bugbear==24.2.6

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -128,6 +128,15 @@ def _job_py_mypy(
         raise RunCommandUnhandledError(f"runem: mypy mis-config detected: {output}")
 
 
+def _delete_old_coverage_reports(root_path: pathlib.Path) -> None:
+    """To avoid false-positives on coverage we delete the coverage report files."""
+    old_coverage_report_files: typing.List[pathlib.Path] = list(
+        root_path.glob(".coverage_report*")
+    )
+    for old_coverage_report in old_coverage_report_files:
+        old_coverage_report.unlink()
+
+
 def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-statements
     **kwargs: typing.Any,
 ) -> JobReturnData:
@@ -154,6 +163,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
     coverage_switches: typing.List[str] = []
     coverage_cfg = root_path / ".coveragerc"
     if options["coverage"]:
+        _delete_old_coverage_reports(root_path)
         assert coverage_cfg.exists()
         coverage_switches = [
             "--cov=.",

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -669,6 +669,8 @@ def test_runem_help(
     As we build features we want to ensure that the help output stays consistent as we
     leverage the argparse system to generate the help for a specific .runem.yml config
     """
+    # Ensure we get fixed-width output.
+    os.environ["RUNEM_FIXED_HELP_WIDTH"] = "1"
     runem_cli_switches: typing.List[str] = ["--help"]
     runem_stdout: typing.List[str]
     error_raised: typing.Optional[BaseException]


### PR DESCRIPTION
### Summary :memo:

Improves the occurance of false-negative and false-positive test passes.

### Details

We do this by:
- fixing the width of rendered and compare help/manifest output.
- deleting `.coverage_report*` files before generating new ones.

These make the dev-focused testing more reliable.
