### PR TITLE
feat(better-job-function-typing): adds stronger typing for job and hook tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 .tox/
 .nox/
-.coverage_report
+.coverage_report*
 .coverage.*
 .cache
 nosetests.xml
@@ -121,6 +121,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+docs/Gemfile
 
 # mypy
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib64/
 node_modules/
 parts/
 sdist/
+tox/
 var/
 wheels/
 pip-wheel-metadata/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 halo
 packaging
 PyYAML
+
+# For pre python3.12 Unpack features we need the `typing_extensions` module to
+# be installed.
+typing_extensions

--- a/runem/hook_manager.py
+++ b/runem/hook_manager.py
@@ -1,6 +1,8 @@
 import typing
 from collections import defaultdict
 
+from typing_extensions import Unpack
+
 from runem.config_metadata import ConfigMetadata
 from runem.job import Job
 from runem.job_execute import job_execute
@@ -10,6 +12,7 @@ from runem.types import (
     HookConfig,
     HookName,
     Hooks,
+    HookSpecificKwargs,
     HooksStore,
     JobConfig,
 )
@@ -69,7 +72,7 @@ class HookManager:
         self,
         hook_name: HookName,
         config_metadata: ConfigMetadata,
-        **kwargs: typing.Any,
+        **kwargs: Unpack[HookSpecificKwargs],
     ) -> None:
         """Invokes all functions registered to a specific hook."""
         hooks: typing.List[HookConfig] = self.hooks_store.get(hook_name, [])

--- a/runem/job_wrapper.py
+++ b/runem/job_wrapper.py
@@ -18,7 +18,7 @@ def get_job_wrapper(job_wrapper: JobWrapper, cfg_filepath: pathlib.Path) -> JobF
         # validate that the command is "understandable" and usable.
         command_string: str = job_wrapper["command"]
         validate_simple_command(command_string)
-        return job_runner_simple_command  # type: ignore # NO_COMMIT
+        return job_runner_simple_command
 
     # if we do not have a simple command address assume we have just an addressed
     # function

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -209,7 +209,7 @@ def _process_jobs(
             with multiprocessing.Pool(processes=num_concurrent_procs) as pool:
                 # use starmap so we can pass down the job-configs and the args and the files
                 in_out_job_run_metadatas[phase] = pool.starmap(
-                    job_execute,
+                    job_execute,  # no kwargs passed for jobs here
                     zip(
                         jobs,
                         repeat(running_jobs),

--- a/scripts/test_hooks/json_validators.py
+++ b/scripts/test_hooks/json_validators.py
@@ -1,12 +1,13 @@
 import pathlib
-import typing
+
+from typing_extensions import Unpack
 
 from runem.run_command import run_command
-from runem.types import FilePathList
+from runem.types import FilePathList, JobKwargs
 
 
 def _json_validate(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> None:
     label = kwargs["label"]
     json_files: FilePathList = kwargs["file_list"]

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -2,13 +2,15 @@ import pathlib
 import shutil
 import typing
 
+from typing_extensions import Unpack
+
 from runem.log import log
 from runem.run_command import RunCommandUnhandledError, run_command
-from runem.types import FilePathList, JobName, JobReturnData, OptionsWritable
+from runem.types import FilePathList, JobKwargs, JobName, JobReturnData, OptionsWritable
 
 
 def _job_py_code_reformat(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> None:
     """Runs python formatting code in serial order as one influences the other."""
     label: JobName = kwargs["label"]
@@ -79,7 +81,7 @@ def _job_py_code_reformat(
 
 
 def _job_py_pylint(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> None:
     python_files: FilePathList = kwargs["file_list"]
     root_path: pathlib.Path = kwargs["root_path"]
@@ -101,7 +103,7 @@ def _job_py_pylint(
 
 
 def _job_py_flake8(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> None:
     python_files: FilePathList = kwargs["file_list"]
     root_path: pathlib.Path = kwargs["root_path"]
@@ -119,7 +121,7 @@ def _job_py_flake8(
 
 
 def _job_py_mypy(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> None:
     python_files: FilePathList = kwargs["file_list"]
     mypy_cmd = ["python3", "-m", "mypy", *python_files]
@@ -138,7 +140,7 @@ def _delete_old_coverage_reports(root_path: pathlib.Path) -> None:
 
 
 def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-statements
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> JobReturnData:
     label: JobName = kwargs["label"]
     options: OptionsWritable = kwargs["options"]
@@ -272,7 +274,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
 
 
 def _install_python_requirements(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> None:
     options: OptionsWritable = kwargs["options"]
     root_path: pathlib.Path = kwargs["root_path"]

--- a/scripts/test_hooks/runem_hooks.py
+++ b/scripts/test_hooks/runem_hooks.py
@@ -1,13 +1,17 @@
 import pathlib
-import typing
 from datetime import timedelta
+
+from typing_extensions import Unpack
+
+from runem.types import HookKwargs
 
 
 def _on_exit_hook(
-    wall_clock_time_saved: timedelta,
-    **kwargs: typing.Any,
+    **kwargs: Unpack[HookKwargs],
 ) -> None:
     """A noddy hook."""
+    assert "wall_clock_time_saved" in kwargs
+    wall_clock_time_saved: timedelta = kwargs["wall_clock_time_saved"]
     root_path: pathlib.Path = pathlib.Path(__file__).parent.parent.parent
     assert (root_path / ".runem.yml").exists()
     times_log: pathlib.Path = root_path / ".times.log"

--- a/scripts/test_hooks/yarn.py
+++ b/scripts/test_hooks/yarn.py
@@ -1,12 +1,13 @@
 import pathlib
-import typing
+
+from typing_extensions import Unpack
 
 from runem.run_command import run_command
-from runem.types import Options, OptionsWritable
+from runem.types import JobKwargs, Options, OptionsWritable
 
 
 def _job_yarn_deps(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> None:
     """Installs the yarn deps."""
     options: Options = kwargs["options"]
@@ -28,7 +29,7 @@ def _job_yarn_deps(
 
 
 def _job_prettier(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[JobKwargs],
 ) -> None:
     """Runs prettifier on files, including json and maybe yml file.
 


### PR DESCRIPTION
### Summary :memo:

Provides better and more robust type hint for job-tasks, self-documenting what is available to developers to use.

### Details

We do this by typing the kwargs convenience variable, for which we need
to use `Unpack` (for back compatibility), and `type_extensions` for
cross-python-version compatibility (i.e. something that work for all
targeted version of python).

As a side-effect of this we get the benefit of seeing when and where we
add extra data into the call-stack for `job_execute()` and it emerges
that we only extend the key-word args when we are calling hooks in a
non-threaded way, which makes sense.

We do several things to achieve this:
  1. We have common parameters passed to both hooks and job-tasks
      - These common parameters make the hooks and job-task feel similar
        to develop.
  2. We put all hook-specific kwargs in one place, and mark each as
     optional.
      - this, for now, is mainly because we only have one hook, so this
        will likely change.
  3. We share and combine kwargs in a range of inheritance types, mainly
     to work with(/around?) python-typing, which isn't great in this
