### PR TITLE
feat(rich): moves to using rich instead of halo for spinners

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -40,6 +40,7 @@
     "pytest", // the python module for testing
     "rcfile", // name of a type of config file
     "refs", // git references
+    "renderable", // used by `rich` module, but also is a valid word when rendering things
     "ronseal", // ronseal, does what it says on the tin
     "runem", // this product
     "setuptools", // python module

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-halo
 packaging
 PyYAML
+
+# For UI Elements
+rich
 
 # For pre python3.12 Unpack features we need the `typing_extensions` module to
 # be installed.


### PR DESCRIPTION
### Summary :memo:

Use the `rich` module instead of the less-well supported `halo` for spinners.

### Details

There are several pros and cons to this:

**Cons**
- **Larger installed size**: Uses 25MB installed instead of 13MB, with a 6.4MB pristine virtual env on a Python 3.12.7 sku, mainly because of the `pygemnts.lexers` dep of `rich`
- **More deps**: `rich` brings in a larger range of deps that we don't use. However we will probably use them in future.

**Pros**
- **Prettier**: The `rich`Spinner looks much prettier.
- **Robust**: The `rich` Spinner is better maintained and therefore more robust, and "feels" more solid.
- **Future features**: With `rich` we can manage our Console output more easily, use colouring, and we have access to many other display features; for instance tables, and other views, for report displays.

Overall `rich` is just a better value proposition, for a cost of +12MB installed. However, at some point, we should consider making `rich` an optional install.
