### PR TITLE
fix(complete-job-count): fixes and simplifies the in-progress report code

### DIFF
--- a/runem/hook_manager.py
+++ b/runem/hook_manager.py
@@ -95,6 +95,7 @@ class HookManager:
             job_execute(
                 job_config,
                 running_jobs={},
+                completed_jobs={},
                 config_metadata=config_metadata,
                 file_lists=file_lists,
                 **kwargs,

--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -111,6 +111,7 @@ def job_execute_inner(
 def job_execute(
     job_config: JobConfig,
     running_jobs: typing.Dict[str, str],
+    completed_jobs: typing.Dict[str, str],
     config_metadata: ConfigMetadata,
     file_lists: FilePathListLookup,
     **kwargs: Unpack[HookSpecificKwargs],
@@ -127,5 +128,6 @@ def job_execute(
         file_lists,
         **kwargs,
     )
+    completed_jobs[this_id] = running_jobs[this_id]
     del running_jobs[this_id]
     return results

--- a/tests/test_job_execute.py
+++ b/tests/test_job_execute.py
@@ -45,7 +45,7 @@ def _job_execute_and_capture_stdout(
     ret_err: typing.Optional[BaseException] = None
     with io.StringIO() as buf, redirect_stdout(buf):
         try:
-            job_execute(job_config, running_jobs, config_metadata, file_lists)
+            job_execute(job_config, running_jobs, {}, config_metadata, file_lists)
         except BaseException as err:  # pylint: disable=broad-exception-caught
             # capture the error and return it
             ret_err = err

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -1675,11 +1675,12 @@ def test_progress_updater_with_running_jobs(
     show_spinner: bool,
 ) -> None:
     running_jobs: typing.Dict[str, str] = {"job1": "running", "job2": "pending"}
+    completed_jobs: typing.Dict[str, str] = {}
     with pytest.raises(SleepCalledError), multiprocessing.Manager() as manager:
         _update_progress(
             "dummy label",
             running_jobs,
-            seen_jobs=[],
+            completed_jobs,
             all_jobs=[],
             is_running=manager.Value("b", True),
             num_workers=1,
@@ -1690,6 +1691,7 @@ def test_progress_updater_with_running_jobs(
 
 def test_progress_updater_with_running_jobs_and_10_jobs(mock_sleep: Mock) -> None:
     running_jobs: typing.Dict[str, str] = {"job1": "running", "job2": "pending"}
+    completed_jobs: typing.Dict[str, str] = {}
     job_config: JobConfig = {
         "addr": {
             "file": __file__,
@@ -1715,7 +1717,7 @@ def test_progress_updater_with_running_jobs_and_10_jobs(mock_sleep: Mock) -> Non
         _update_progress(
             "dummy label",
             running_jobs,
-            seen_jobs=[],
+            completed_jobs,
             all_jobs=all_jobs,
             is_running=manager.Value("b", True),
             num_workers=1,
@@ -1726,11 +1728,12 @@ def test_progress_updater_with_running_jobs_and_10_jobs(mock_sleep: Mock) -> Non
 
 def test_progress_updater_without_running_jobs(mock_sleep: Mock) -> None:
     running_jobs: typing.Dict[str, str] = {}
+    completed_jobs: typing.Dict[str, str] = {}
     with pytest.raises(SleepCalledError), multiprocessing.Manager() as manager:
         _update_progress(
             "dummy label",
             running_jobs,
-            seen_jobs=[],
+            completed_jobs,
             all_jobs=[],
             is_running=manager.Value("b", True),
             num_workers=1,
@@ -1741,11 +1744,12 @@ def test_progress_updater_without_running_jobs(mock_sleep: Mock) -> None:
 
 def test_progress_updater_with_empty_running_jobs(mock_sleep: Mock) -> None:
     running_jobs: typing.Dict[str, str] = {"job1": ""}
+    completed_jobs: typing.Dict[str, str] = {}
     with pytest.raises(SleepCalledError), multiprocessing.Manager() as manager:
         _update_progress(
             "dummy label",
             running_jobs,
-            seen_jobs=[],
+            completed_jobs,
             all_jobs=[],
             is_running=manager.Value("b", True),
             num_workers=1,
@@ -1769,7 +1773,7 @@ def test_progress_updater_with_false(show_spinner: bool) -> None:
         _update_progress(
             "dummy label",
             running_jobs,
-            [],
+            {},
             [],
             manager.Value("b", False),
             1,


### PR DESCRIPTION
### Summary :memo:

Fixes the in-progress report, so it show accurate job-completed counts.

### Details

The core problem was that the remaining-job-count didn't match the number of job-labels that were being shown.

The root-cause was due to some of the job-tasks completing before the `_update_progress()` thread had started monitoring the jobs.

We fix this by adding a new parameter to the job-executer that tracks when job completed. It's a very simple fix and reduces the overall complexity for about the same cost of threading-primitives.
