### PR TITLE
Chore/more job task context

### DIFF
--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -83,6 +83,7 @@ def job_execute_inner(
     try:
         # Define the common args for all jobs and hooks.
         job_k_args: JobKwargs = {
+            "config_metadata": config_metadata,
             "file_list": file_list,
             "job": job_config,
             "label": Job.get_job_name(job_config),

--- a/runem/types/types_jobs.py
+++ b/runem/types/types_jobs.py
@@ -35,6 +35,9 @@ from runem.types.common import FilePathList, PhaseName
 from runem.types.options import Options
 from runem.types.runem_config import JobConfig
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from runem.config_metadata import ConfigMetadata
+
 ReportName = str
 ReportUrl = typing.Union[str, pathlib.Path]
 ReportUrlInfo = typing.Tuple[ReportName, ReportUrl]
@@ -79,12 +82,12 @@ class CommonKwargs(
     can access from both hooks and job-tasks.
     """
 
+    config_metadata: "ConfigMetadata"  # gives greater context to jobs and hooks
     job: JobConfig  # the job or hook task spec ¢ TODO: rename this
     label: str  # the name of the hook or the job-label
     options: Options  # options passed in on the command line
     procs: int  # the max number of concurrent procs to run
     root_path: pathlib.Path  # the path where the .runem.yml file is
-    # TODO: config_metadata: ConfigMetadata
     verbose: bool  # control log verbosity
 
 


### PR DESCRIPTION
### Summary :memo:

Allows job-runs to modify behaviour based on runem context.

### Details

For instance, if we have multiple jobs that overlap, we can, early-return from lower performing jobs, if wanted.

This also allows later one, for use to generate jobs and inject new data into the context.

NOTE: for now the context is NOT read-only, which is the right thing to do, for now, but this may change.
