### PR TITLE
Feat/pass files to simple commands

### DIFF
--- a/runem/job_runner_simple_command.py
+++ b/runem/job_runner_simple_command.py
@@ -1,8 +1,11 @@
 import shlex
 import typing
 
+from typing_extensions import Unpack
+
 from runem.run_command import run_command
 from runem.types.runem_config import JobConfig
+from runem.types.types_jobs import AllKwargs
 
 
 def validate_simple_command(command_string: str) -> typing.List[str]:
@@ -12,7 +15,7 @@ def validate_simple_command(command_string: str) -> typing.List[str]:
 
 
 def job_runner_simple_command(
-    **kwargs: typing.Any,
+    **kwargs: Unpack[AllKwargs],
 ) -> None:
     """Parses the command and tries to run it via the system.
 

--- a/runem/job_runner_simple_command.py
+++ b/runem/job_runner_simple_command.py
@@ -6,7 +6,7 @@ from runem.types.runem_config import JobConfig
 
 
 def validate_simple_command(command_string: str) -> typing.List[str]:
-    # use shlex to handle parsing of the command string, a non-trivial problem.
+    """Use shlex to handle parsing of the command string, a non-trivial problem."""
     split_command: typing.List[str] = shlex.split(command_string)
     return split_command
 

--- a/tests/test_job_runner_simple_command.py
+++ b/tests/test_job_runner_simple_command.py
@@ -1,4 +1,5 @@
 import io
+import typing
 from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -40,6 +41,57 @@ def test_job_runner_simple_command(mock_run_command: Mock) -> None:
         file_list=[],
         job={"command": "echo 'testing job_runner_simple_command'"},
         label="echo 'testing job_runner_simple_command'",
+        options={},
+        procs=1,
+        root_path=Path("."),
+        verbose=True,
+    )
+
+
+@patch(
+    "runem.job_runner_simple_command.run_command",
+    # return_value=None,
+)
+def test_job_runner_simple_command_with_file_list(mock_run_command: Mock) -> None:
+    """Tests the basics of job_runner_simple_command."""
+    test_cmd_string: str = (
+        'echo "some option before files" {file_list} "some option after files"'
+    )
+    job_config: JobConfig = {
+        "command": test_cmd_string,
+    }
+    config_metadata: ConfigMetadata = gen_dummy_config_metadata()
+    file_list: typing.List[typing.Union[str, Path]] = [
+        Path("file1"),
+        "file2",
+        "file with spaces",
+    ]
+    with io.StringIO() as buf, redirect_stdout(buf):
+        ret: None = job_runner_simple_command(  # type: ignore[func-returns-value]
+            file_list=file_list,  # type: ignore[arg-type] # intentional type mismatch
+            job=job_config,
+            label=Job.get_job_name(job_config),
+            options=config_metadata.options,  # type: ignore
+            procs=config_metadata.args.procs,
+            root_path=Path("."),
+            verbose=True,  # config_metadata.args.verbose,
+        )
+        run_command_stdout = buf.getvalue()
+
+    assert ret is None
+    assert run_command_stdout.split("\n") == [""]
+    mock_run_command.assert_called_once_with(
+        cmd=[
+            "echo",
+            '"some option before files"',
+            "file1",
+            "file2",
+            '"file with spaces"',
+            '"some option after files"',
+        ],
+        file_list=file_list,
+        job=job_config,
+        label=test_cmd_string,
         options={},
         procs=1,
         root_path=Path("."),

--- a/tests/test_job_runner_simple_command.py
+++ b/tests/test_job_runner_simple_command.py
@@ -1,10 +1,13 @@
 import io
 from contextlib import redirect_stdout
+from pathlib import Path
 from unittest.mock import Mock, patch
 
+from runem.config_metadata import ConfigMetadata
 from runem.job import Job
 from runem.job_runner_simple_command import job_runner_simple_command
 from runem.types.runem_config import JobConfig
+from tests.test_runem import gen_dummy_config_metadata
 
 
 @patch(
@@ -16,12 +19,13 @@ def test_job_runner_simple_command(mock_run_command: Mock) -> None:
     job_config: JobConfig = {
         "command": "echo 'testing job_runner_simple_command'",
     }
+    config_metadata: ConfigMetadata = gen_dummy_config_metadata()
     with io.StringIO() as buf, redirect_stdout(buf):
         ret: None = job_runner_simple_command(  # type: ignore[func-returns-value]
-            # options=config_metadata.options,  # type: ignore
-            # file_list=file_list,
-            # procs=config_metadata.args.procs,
-            # root_path=root_path,
+            options=config_metadata.options,  # type: ignore
+            file_list=[],
+            procs=config_metadata.args.procs,
+            root_path=Path("."),
             verbose=True,  # config_metadata.args.verbose,
             # unpack useful data points from the job_config
             label=Job.get_job_name(job_config),
@@ -33,7 +37,11 @@ def test_job_runner_simple_command(mock_run_command: Mock) -> None:
     assert run_command_stdout.split("\n") == [""]
     mock_run_command.assert_called_once_with(
         cmd=["echo", '"testing job_runner_simple_command"'],
-        verbose=True,
-        label="echo 'testing job_runner_simple_command'",
+        file_list=[],
         job={"command": "echo 'testing job_runner_simple_command'"},
+        label="echo 'testing job_runner_simple_command'",
+        options={},
+        procs=1,
+        root_path=Path("."),
+        verbose=True,
     )

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -1780,7 +1780,7 @@ def test_progress_updater_with_false(show_spinner: bool) -> None:
         )
 
 
-def _dummy_config_metadata() -> ConfigMetadata:
+def gen_dummy_config_metadata() -> ConfigMetadata:
     config_metadata: ConfigMetadata = ConfigMetadata(
         cfg_filepath=pathlib.Path(__file__),
         phases=("dummy phase 1",),
@@ -1809,7 +1809,7 @@ def _dummy_config_metadata() -> ConfigMetadata:
 
 
 DUMMY_MAIN_RETURN: MainReturnType = (
-    _dummy_config_metadata(),  # ConfigMetadata,
+    gen_dummy_config_metadata(),  # ConfigMetadata,
     {},  # job_run_metadatas,
     IntentionalTestError(),
 )


### PR DESCRIPTION
### Summary :memo:

Allow "{file_list}" in the simple-commands.

### Details

This means that we can use file-filters and tags in a simpler, faster and more convenient way via the simple-commands option in `runem`, rather than having to create a python-based function to accept the parameters.

This also establishes the basis for adding more ctx-specific options into simple commands, eventually meaning we can do away with many of the python function we use across runem-using projects.
