### PR TITLE
feat(where-errors): errors when 'tags' and 'phase' are not under 'where'

### DIFF
--- a/runem/job.py
+++ b/runem/job.py
@@ -11,6 +11,12 @@ class NoJobName(ValueError):
     pass
 
 
+class BadWhenConfigLocation(ValueError):
+    """The job-config does not contain a label and can't be coerced to crate one."""
+
+    pass
+
+
 class Job:
     """A class with utility functions for jobs.
 
@@ -27,6 +33,16 @@ class Job:
 
         TODO: make a non-static member function
         """
+        if "tags" in job:
+            raise BadWhenConfigLocation(
+                "'tags' should be listed inside the 'when' config for jobs"
+            )
+
+        if "phase" in job:
+            raise BadWhenConfigLocation(
+                "'phase' should be listed inside the 'when' config for jobs"
+            )
+
         if "when" not in job or "tags" not in job["when"]:
             # handle the special case where we have No tags
             return None

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 import pytest
 
-from runem.job import Job, NoJobName
+from runem.job import BadWhenConfigLocation, Job, NoJobName
 from runem.types.common import FilePathList, JobTags
 from runem.types.filters import FilePathListLookup
 from runem.types.runem_config import JobConfig
@@ -25,6 +25,24 @@ def test_get_job_tags(
 ) -> None:
     result: typing.Optional[JobTags] = Job.get_job_tags(job_config)
     assert result == expected_result
+
+
+def test_get_job_tags_bad_tags_path() -> None:
+    """Tests that the 'tags' entry is on 'when' and not on root."""
+    job_config: JobConfig = {  # type: ignore[typeddict-unknown-key]
+        "tags": ["dummy tags"],
+    }
+    with pytest.raises(BadWhenConfigLocation):
+        Job.get_job_tags(job_config)
+
+
+def test_get_job_tags_bad_phase_path() -> None:
+    """Tests that the 'phase' entry is on 'when' and not on root."""
+    job_config: JobConfig = {  # type: ignore[typeddict-unknown-key]
+        "phase": "dummy tags",
+    }
+    with pytest.raises(BadWhenConfigLocation):
+        Job.get_job_tags(job_config)
 
 
 @pytest.fixture(name="file_lists")


### PR DESCRIPTION
### Summary :memo:

Helps catch misconfigs early.

### Details

We weren't getting errors when `tags` was placed on the wrong section of the job-config. This simply errors if `tags` and `phase` fields are on the root, which is going to be a common mistake, probably.

I do wonder if we should allow `tags` and `phase` (and so on) on the root as using `where` is just syntax sugar.
