### PR TITLE
Feat/option switches in simple commands

### DIFF
--- a/runem/job_runner_simple_command.py
+++ b/runem/job_runner_simple_command.py
@@ -3,8 +3,10 @@ import typing
 
 from typing_extensions import Unpack
 
+from runem.config_metadata import ConfigMetadata
 from runem.run_command import run_command
 from runem.types.common import FilePathList
+from runem.types.options import OptionsWritable
 from runem.types.runem_config import JobConfig
 from runem.types.types_jobs import AllKwargs
 
@@ -36,8 +38,24 @@ def job_runner_simple_command(
             "{file_list}", " ".join(file_list_with_quotes)
         )
 
+    config_metadata: ConfigMetadata = kwargs["config_metadata"]
+    options: OptionsWritable = config_metadata.options
+    command_string_options: str = command_string_files
+    for name, value in options.items():
+        # For now, just pass `--option-name`, `--check` or similar to the
+        # command line. At some point we will want this to be cleverer, but
+        # this will do for now.
+        option_search = f"{{{name}}}"
+        if option_search in command_string_files:
+            replacement = ""
+            if value:
+                replacement = f"--{name}"
+            command_string_options = command_string_options.replace(
+                option_search, replacement
+            )
+
     # use shlex to handle parsing of the command string, a non-trivial problem.
-    cmd = validate_simple_command(command_string_files)
+    cmd = validate_simple_command(command_string_options)
 
     # preserve quotes for consistent handling of strings and avoid the "word
     # splitting" problem for unix-like shells.

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -191,6 +191,7 @@ def _job_py_pytest(  # noqa: C901 # pylint: disable=too-many-branches,too-many-s
         "python3",
         "-m",
         "pytest",
+        "--color=yes",
         *threading_switches,
         # "-c",
         # str(pytest_cfg),

--- a/tests/test_job_runner_simple_command.py
+++ b/tests/test_job_runner_simple_command.py
@@ -2,7 +2,7 @@ import io
 import typing
 from contextlib import redirect_stdout
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from runem.config_metadata import ConfigMetadata
 from runem.job import Job
@@ -23,6 +23,7 @@ def test_job_runner_simple_command(mock_run_command: Mock) -> None:
     config_metadata: ConfigMetadata = gen_dummy_config_metadata()
     with io.StringIO() as buf, redirect_stdout(buf):
         ret: None = job_runner_simple_command(  # type: ignore[func-returns-value]
+            config_metadata=config_metadata,
             options=config_metadata.options,  # type: ignore
             file_list=[],
             procs=config_metadata.args.procs,
@@ -38,10 +39,11 @@ def test_job_runner_simple_command(mock_run_command: Mock) -> None:
     assert run_command_stdout.split("\n") == [""]
     mock_run_command.assert_called_once_with(
         cmd=["echo", '"testing job_runner_simple_command"'],
+        config_metadata=ANY,
         file_list=[],
         job={"command": "echo 'testing job_runner_simple_command'"},
         label="echo 'testing job_runner_simple_command'",
-        options={},
+        options=ANY,
         procs=1,
         root_path=Path("."),
         verbose=True,
@@ -71,6 +73,7 @@ def test_job_runner_simple_command_with_file_list(mock_run_command: Mock) -> Non
             file_list=file_list,  # type: ignore[arg-type] # intentional type mismatch
             job=job_config,
             label=Job.get_job_name(job_config),
+            config_metadata=config_metadata,
             options=config_metadata.options,  # type: ignore
             procs=config_metadata.args.procs,
             root_path=Path("."),
@@ -89,10 +92,63 @@ def test_job_runner_simple_command_with_file_list(mock_run_command: Mock) -> Non
             '"file with spaces"',
             '"some option after files"',
         ],
+        config_metadata=ANY,
         file_list=file_list,
         job=job_config,
         label=test_cmd_string,
-        options={},
+        options=ANY,
+        procs=1,
+        root_path=Path("."),
+        verbose=True,
+    )
+
+
+@patch(
+    "runem.job_runner_simple_command.run_command",
+    # return_value=None,
+)
+def test_job_runner_simple_command_with_option(mock_run_command: Mock) -> None:
+    """Tests that option-passing to jobs, pass --option_on but not --option_off."""
+    test_cmd_string: str = (
+        'echo "some option before switch" {option_on} {option_off} "some option after switch"'
+    )
+    job_config: JobConfig = {
+        "command": test_cmd_string,
+    }
+    config_metadata: ConfigMetadata = gen_dummy_config_metadata()
+    file_list: typing.List[typing.Union[str, Path]] = [
+        Path("file1"),
+        "file2",
+        "file with spaces",
+    ]
+    with io.StringIO() as buf, redirect_stdout(buf):
+        ret: None = job_runner_simple_command(  # type: ignore[func-returns-value]
+            file_list=file_list,  # type: ignore[arg-type] # intentional type mismatch
+            job=job_config,
+            label=Job.get_job_name(job_config),
+            config_metadata=config_metadata,
+            options=config_metadata.options,  # type: ignore
+            procs=config_metadata.args.procs,
+            root_path=Path("."),
+            verbose=True,  # config_metadata.args.verbose,
+        )
+        run_command_stdout = buf.getvalue()
+
+    assert ret is None
+    assert run_command_stdout.split("\n") == [""]
+    mock_run_command.assert_called_once_with(
+        cmd=[
+            "echo",
+            '"some option before switch"',
+            "--option_on",
+            # Not this -> "--option_off",
+            '"some option after switch"',
+        ],
+        config_metadata=ANY,
+        file_list=file_list,
+        job=job_config,
+        label=test_cmd_string,
+        options={"option_on": True, "option_off": False},
         procs=1,
         root_path=Path("."),
         verbose=True,

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -1803,7 +1803,7 @@ def gen_dummy_config_metadata() -> ConfigMetadata:
         phases_to_run=set(),  # JobPhases,
         tags_to_run=set(),  # ignored JobTags,
         tags_to_avoid=set(),  # ignored  JobTags,
-        options=InformativeDict({}),  # Options,
+        options=InformativeDict({"option_on": True, "option_off": False}),  # Options,
     )
     return config_metadata
 


### PR DESCRIPTION
### Summary :memo:

Allow simple switches to be passed to simple runem jobs

### Details

Currently we only have boolean `options` in runem. This feature reflects that opt-in nature, adding `--{option}` to simple commands if that option is set on the command line, or skips it if not.
