### PR TITLE
chore(docs): improves the help comments for --tags options

### DIFF
--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -138,7 +138,9 @@ def parse_args(
         nargs="+",
         default=config_metadata.all_job_tags,
         help=(
-            "Only jobs with the given tags. "
+            # TODO: clarify the logic by which we add/remove jobs based on tags
+            #       e.g. exclusive-in, union, x-or etc.
+            "Only run jobs with the given tags. "
             f"Defaults to '{sorted(config_metadata.all_job_tags)}'."
         ),
         required=False,

--- a/tests/data/help_output.3.10.txt
+++ b/tests/data/help_output.3.10.txt
@@ -42,7 +42,7 @@ phases:
 
 tags:
   --tags TAGS [TAGS ...]
-                        Only jobs with the given tags. Defaults to '['dummy tag 1', 'dummy tag 2', 'tag only on job 1', 'tag only on job 2']'.
+                        Only run jobs with the given tags. Defaults to '['dummy tag 1', 'dummy tag 2', 'tag only on job 1', 'tag only on job 2']'.
   --not-tags TAGS_EXCLUDED [TAGS_EXCLUDED ...]
                         Removes one or more tags from the list of job tags to be run. Options are '['dummy tag 1', 'dummy tag 2', 'tag only on job 1', 'tag only on job 2']'.
 

--- a/tests/data/help_output.3.11.txt
+++ b/tests/data/help_output.3.11.txt
@@ -42,7 +42,7 @@ phases:
 
 tags:
   --tags TAGS [TAGS ...]
-                        Only jobs with the given tags. Defaults to '['dummy tag 1', 'dummy tag 2', 'tag only on job 1', 'tag only on job 2']'.
+                        Only run jobs with the given tags. Defaults to '['dummy tag 1', 'dummy tag 2', 'tag only on job 1', 'tag only on job 2']'.
   --not-tags TAGS_EXCLUDED [TAGS_EXCLUDED ...]
                         Removes one or more tags from the list of job tags to be run. Options are '['dummy tag 1', 'dummy tag 2', 'tag only on job 1', 'tag only on job 2']'.
 


### PR DESCRIPTION
### Summary :memo:

Minor --help fix

### Details

Makes it clearer what the intended use of `--tags` is in help text.
