### PR TITLE
chore(types) fixes exports for JobReturn type

### DIFF
--- a/runem/types/__init__.py
+++ b/runem/types/__init__.py
@@ -1,11 +1,12 @@
 from runem.types.common import FilePathList, JobName
 from runem.types.options import Options
-from runem.types.types_jobs import HookKwargs, JobKwargs, JobReturnData
+from runem.types.types_jobs import HookKwargs, JobKwargs, JobReturn, JobReturnData
 
 __all__ = [
     "FilePathList",
     "HookKwargs",
     "JobName",
+    "JobReturn",
     "JobReturnData",
     "Options",
     "JobKwargs",


### PR DESCRIPTION
### Summary :memo:

Exports the correct type for runem hooks

### Details

This was missing previously, or at least the wrong type was exported. This allows hooks to use the right version.