### PR TITLE
fix(log-verbosity): fixes verbosity bug when not showing the spinner

### DIFF
--- a/runem/runem.py
+++ b/runem/runem.py
@@ -164,6 +164,7 @@ def _update_progress(
             else:
                 if last_running_jobs_set != running_jobs_set:
                     RICH_CONSOLE.log(report)
+                    last_running_jobs_set = running_jobs_set
 
             # Sleep for reduced CPU usage
             time.sleep(0.1)


### PR DESCRIPTION
### Summary :memo:

We were getting log spam in ci/cd tasks where we disable the spinner.

### Details

We were showing the running procs on every tick, instead of just the changes to the running procs, if any.

We should probably detect if we're in a live-view or in a piped-view, and disable spinners automagically.