### PR TITLE
Feat/better error display

### DIFF
--- a/runem/blocking_print.py
+++ b/runem/blocking_print.py
@@ -13,7 +13,13 @@ def _reset_console() -> Console:
 
     RICH_CONSOLE = Console(
         log_path=False,  # Do NOT print the source path.
-        markup=False,  # Do NOT print markup e.g. `[blink]Don't Panic![/blink]`.
+        # We allow markup here, BUT stdout/stderr from other procs should have
+        # `escape()` called on them so they don't error here.
+        # This means 'rich' effects/colors can be judiciously applied:
+        # e.g. `[blink]Don't Panic![/blink]`.
+        markup=True,
+        # `highlight` is what colourises string and number in prin() calls.
+        highlight=False,
     )
     return RICH_CONSOLE
 
@@ -31,7 +37,8 @@ def _reset_console_for_tests() -> None:
     RICH_CONSOLE = Console(
         log_path=False,  # Do NOT print the source path.
         log_time=False,  # Do not prefix with log time e.g. `[time] log message`.
-        markup=False,  # Do NOT print markup e.g. `[blink]Don't Panic![/blink]`.
+        markup=True,  # Allow some markup e.g. `[blink]Don't Panic![/blink]`.
+        highlight=False,
         width=999,  # A very wide width.
     )
 

--- a/runem/blocking_print.py
+++ b/runem/blocking_print.py
@@ -18,7 +18,8 @@ def _reset_console() -> Console:
         # This means 'rich' effects/colors can be judiciously applied:
         # e.g. `[blink]Don't Panic![/blink]`.
         markup=True,
-        # `highlight` is what colourises string and number in prin() calls.
+        # `highlight` is what colourises string and number in print() calls.
+        # We do not want this to be auto-magic.
         highlight=False,
     )
     return RICH_CONSOLE

--- a/runem/log.py
+++ b/runem/log.py
@@ -28,7 +28,7 @@ def log(
 
     if decorate:
         # Make it clear that the message comes from `runem` internals.
-        msg = f"runem: {msg}"
+        msg = f"[light_slate_grey]runem[/light_slate_grey]: {msg}"
 
     # print in a blocking manner, waiting for system resources to free up if a
     # runem job is contending on stdout or similar.
@@ -36,8 +36,8 @@ def log(
 
 
 def warn(msg: str) -> None:
-    log(f"WARNING: {msg}")
+    log(f"[yellow]WARNING[/yellow]: {msg}")
 
 
 def error(msg: str) -> None:
-    log(f"ERROR: {msg}")
+    log(f"[red]ERROR[/red]: {msg}")

--- a/runem/log.py
+++ b/runem/log.py
@@ -3,12 +3,31 @@ import typing
 from runem.blocking_print import blocking_print
 
 
-def log(msg: str = "", decorate: bool = True, end: typing.Optional[str] = None) -> None:
+def log(
+    msg: str = "",
+    decorate: bool = True,
+    end: typing.Optional[str] = None,
+) -> None:
     """Thin wrapper around 'print', change the 'msg' & handles system-errors.
 
     One way we change it is to decorate the output with 'runem'
+
+    Parameters:
+        msg: str - the message to log out. Any `rich` markup will be escaped
+                   and not applied.
+        decorate: str - whether to add runem-specific prefix text. We do this
+                        to identify text that comes from the app vs text that
+                        comes from hooks or other third-parties.
+        end: Optional[str] - same as the end option used by `print()` and
+                             `rich`
+    Returns:
+        Nothing
     """
+    # Remove any markup as it will probably error, if unsanitised.
+    # msg = escape(msg)
+
     if decorate:
+        # Make it clear that the message comes from `runem` internals.
         msg = f"runem: {msg}"
 
     # print in a blocking manner, waiting for system resources to free up if a

--- a/runem/report.py
+++ b/runem/report.py
@@ -211,7 +211,10 @@ def _print_reports_by_phase(
         for job_report_url_info in report_urls:
             if not job_report_url_info:
                 continue
-            log(f"report: {str(job_report_url_info[0])}: {str(job_report_url_info[1])}")
+            log(
+                f"report: [blue]{str(job_report_url_info[0])}[/blue]: "
+                f"{str(job_report_url_info[1])}"
+            )
 
 
 def report_on_run(

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -57,7 +57,7 @@ from runem.types.types_jobs import (
     JobRunMetadatasByPhase,
     JobTiming,
 )
-from runem.utils import printable_set
+from runem.utils import printable_set_coloured
 
 
 def _determine_run_parameters(argv: typing.List[str]) -> ConfigMetadata:
@@ -124,7 +124,7 @@ class DummySpinner(ConsoleRenderable):  # pragma: no cover
 
 
 def _update_progress(
-    label: str,
+    phase: str,
     running_jobs: typing.Dict[str, str],
     completed_jobs: typing.Dict[str, str],
     all_jobs: Jobs,
@@ -156,12 +156,15 @@ def _update_progress(
 
             # Progress report
             progress: str = f"{len(completed_jobs)}/{len(all_jobs)}"
-            running_jobs_list = printable_set(
-                running_jobs_set
+            running_jobs_list = printable_set_coloured(
+                running_jobs_set,
+                "blue",
             )  # Reflect current running jobs accurately
-            report: str = f"{label}: {progress}({num_workers}): {running_jobs_list}"
+            report: str = (
+                f"[green]{phase}[/green]: {progress}({num_workers}): {running_jobs_list}"
+            )
             if show_spinner:
-                spinner.text = report
+                spinner.text = Text.from_markup(report)
             else:
                 if last_running_jobs_set != running_jobs_set:
                     RICH_CONSOLE.log(report)
@@ -198,7 +201,7 @@ def _process_jobs(
     num_concurrent_procs: int = min(max_num_concurrent_procs, len(jobs))
     log(
         (
-            f"Running '{phase}' with {num_concurrent_procs} workers (of "
+            f"Running '[green]{phase}[/green]' with {num_concurrent_procs} workers (of "
             f"{max_num_concurrent_procs} max) processing {len(jobs)} jobs"
         )
     )
@@ -374,14 +377,15 @@ def timed_main(argv: typing.List[str]) -> None:
     system_time_spent, wall_clock_time_saved = report_on_run(
         phase_run_oder, job_run_metadatas, time_taken
     )
-    message: str = "DONE: runem took"
+    message: str = "[green bold]DONE[/green bold]: runem took"
     if failure_exception:
         message = "[red bold]FAILED[/red bold]: your jobs failed after"
     log(
         (
             f"{message}: {time_taken.total_seconds()}s, "
-            f"saving you {wall_clock_time_saved.total_seconds()}s, "
-            f"without runem you would have waited {system_time_spent.total_seconds()}s"
+            f"saving you [green]{wall_clock_time_saved.total_seconds()}s[/green], "
+            "without runem you would have waited "
+            f"[red]{system_time_spent.total_seconds()}s[/red]"
         )
     )
 

--- a/runem/utils.py
+++ b/runem/utils.py
@@ -4,3 +4,15 @@ import typing
 def printable_set(some_set: typing.Set[typing.Any]) -> str:
     """Get a printable, deterministic string version of a set."""
     return ", ".join([f"'{set_item}'" for set_item in sorted(list(some_set))])
+
+
+def printable_set_coloured(some_set: typing.Set[typing.Any], colour: str) -> str:
+    """`printable_set` but elements are surrounded with colour mark-up.
+
+    Parameters:
+        some_set: a set of anything
+        colour: a `rich` Console supported colour
+    """
+    return ", ".join(
+        [f"'[{colour}]{set_item}[/{colour}]'" for set_item in sorted(list(some_set))]
+    )

--- a/tests/intentional_test_error.py
+++ b/tests/intentional_test_error.py
@@ -1,5 +1,8 @@
-class IntentionalTestError(RuntimeError):
+from runem.run_command import RunemJobError
+
+
+class IntentionalTestError(RunemJobError):
     pass
 
     def __init__(self) -> None:
-        super().__init__(self, "expected test error")
+        super().__init__(friendly_message="expected test error", stdout="dummy stdout")

--- a/tests/test_hook_manager.py
+++ b/tests/test_hook_manager.py
@@ -167,8 +167,8 @@ def test_invoke_hooks(do_hooks: bool, hook_man: HookManager) -> None:
             "runem: job: running: 'HookName.ON_EXIT'",
             'runem: running: start: HookName.ON_EXIT: echo "mock_hook_function_bash '
             'called aok"',
-            'runem: HookName.ON_EXIT: "mock_hook_function_bash called aok"',
-            "",
+            '| HookName.ON_EXIT: "mock_hook_function_bash called aok"',
+            "| HookName.ON_EXIT: ",
             'runem: running: done: HookName.ON_EXIT: echo "mock_hook_function_bash called '
             'aok"',
             "runem: job: DONE: 'HookName.ON_EXIT': 0:00:00",


### PR DESCRIPTION
### Summary :memo:

Much better rendering of error output on failed jobs (key aim of PR)

### Details

We also fix:
- Spinner rendering.
- 'Random' colouring of runem's output thanks to `rich`'s `highlight` option being on by default.
- Stops `rich` from applying bad markup to stdout when it shouldn't.
