### PR TITLE
feat(log): changes the semantics of log's 'decorate' to allow overriding

### DIFF
--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -294,12 +294,12 @@ def parse_args(
     error_on_log_logic(args.verbose, args.silent)
 
     if args.show_root_path_and_exit:
-        log(str(config_metadata.cfg_filepath.parent), decorate=False)
+        log(str(config_metadata.cfg_filepath.parent), prefix=False)
         # cleanly exit
         sys.exit(0)
 
     if args.show_version_and_exit:
-        log(str(get_runem_version()), decorate=False)
+        log(str(get_runem_version()), prefix=False)
         # cleanly exit
         sys.exit(0)
 

--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -105,7 +105,7 @@ def job_execute_inner(
         reports = function(**all_k_args)
     except BaseException:  # pylint: disable=broad-exception-caught
         # log that we hit an error on this job and re-raise
-        log(decorate=False)
+        log(prefix=False)
         error(f"job: job '{Job.get_job_name(job_config)}' failed to complete!")
         # re-raise
         raise

--- a/runem/job_filter.py
+++ b/runem/job_filter.py
@@ -101,21 +101,21 @@ def filter_jobs(  # noqa: C901
         if tags_to_run:
             log(
                 f"filtering for tags {printable_set(tags_to_run)}",
-                decorate=True,
+                prefix=True,
                 end="",
             )
         if tags_to_avoid:
             if tags_to_run:
-                log(", ", decorate=False, end="")
+                log(", ", prefix=False, end="")
             else:
-                log(decorate=True, end="")
+                log(prefix=True, end="")
             log(
                 f"excluding jobs with tags {printable_set(tags_to_avoid)}",
-                decorate=False,
+                prefix=False,
                 end="",
             )
         if tags_to_run or tags_to_avoid:
-            log(decorate=False)
+            log(prefix=False)
     filtered_jobs: PhaseGroupedJobs = defaultdict(list)
     for phase in config_metadata.phases:
         if phase not in phases_to_run:

--- a/runem/log.py
+++ b/runem/log.py
@@ -5,7 +5,7 @@ from runem.blocking_print import blocking_print
 
 def log(
     msg: str = "",
-    decorate: bool = True,
+    prefix: typing.Optional[bool] = None,
     end: typing.Optional[str] = None,
 ) -> None:
     """Thin wrapper around 'print', change the 'msg' & handles system-errors.
@@ -26,7 +26,10 @@ def log(
     # Remove any markup as it will probably error, if unsanitised.
     # msg = escape(msg)
 
-    if decorate:
+    if prefix is None:
+        prefix = True
+
+    if prefix:
         # Make it clear that the message comes from `runem` internals.
         msg = f"[light_slate_grey]runem[/light_slate_grey]: {msg}"
 

--- a/runem/run_command.py
+++ b/runem/run_command.py
@@ -93,13 +93,13 @@ def _log_command_execution(
     if verbose:
         log(
             f"running: start: [blue]{label}[/blue]: [yellow]{cmd_string}[yellow]",
-            decorate=decorate_logs,
+            prefix=decorate_logs,
         )
         if valid_exit_ids is not None:
             valid_exit_strs = ",".join(str(exit_code) for exit_code in valid_exit_ids)
             log(
                 f"\tallowed return ids are: [green]{valid_exit_strs}[/green]",
-                decorate=decorate_logs,
+                prefix=decorate_logs,
             )
 
         if env_overrides:
@@ -108,11 +108,11 @@ def _log_command_execution(
             )
             log(
                 f"ENV OVERRIDES: [yellow]{env_overrides_as_string} {cmd_string}[/yellow]",
-                decorate=decorate_logs,
+                prefix=decorate_logs,
             )
 
         if cwd:
-            log(f"cwd: {str(cwd)}", decorate=decorate_logs)
+            log(f"cwd: {str(cwd)}", prefix=decorate_logs)
 
 
 def run_command(  # noqa: C901
@@ -175,7 +175,7 @@ def run_command(  # noqa: C901
                         parse_stdout(
                             line, prefix=f"[green]| [/green][blue]{label}[/blue]: "
                         ),
-                        decorate=False,
+                        prefix=False,
                     )
 
             # Wait for the subprocess to finish and get the exit code
@@ -219,7 +219,7 @@ def run_command(  # noqa: C901
     if verbose:
         log(
             f"running: done: [blue]{label}[/blue]: [yellow]{cmd_string}[/yellow]",
-            decorate=decorate_logs,
+            prefix=decorate_logs,
         )
 
     if record_sub_job_time is not None:

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -293,8 +293,8 @@ def _main(
         log(f"found {len(file_lists)} batches, ", end="")
         for tag in sorted(file_lists.keys()):
             file_list = file_lists[tag]
-            log(f"{len(file_list)} '{tag}' files, ", decorate=False, end="")
-        log(decorate=False)  # new line
+            log(f"{len(file_list)} '{tag}' files, ", prefix=False, end="")
+        log(prefix=False)  # new line
 
     filtered_jobs_by_phase: PhaseGroupedJobs = filter_jobs(
         config_metadata=config_metadata,


### PR DESCRIPTION
### Summary :memo:

"decorate' was meaningless, 'prefix' is better. This will break any uses of the log function

### Details

Also renames the log API's param decorate -> prefix.

This better represents the intent of the param as decorate was adding a default prefix.
