### PR TITLE
Chore/ruff

### DIFF
--- a/.runem.yml
+++ b/.runem.yml
@@ -35,6 +35,11 @@
           type: bool
       - option:
           default: true
+          name: fix
+          desc: try to auto fix whenever possible
+          type: bool
+      - option:
+          default: true
           desc: formats docs and comments in whatever job can do so
           name: docformatter
           type: bool
@@ -53,6 +58,11 @@
           name: profile
           desc: generate profile information in jobs that can
           type: bool
+      - option:
+          default: true
+          name: ruff
+          type: bool
+          desc: prefer running formatting with ruff instead of isort, black and docformatter
       - option:
           default: true
           name: unit-test
@@ -75,14 +85,15 @@
 - job:
     addr:
       file: scripts/test_hooks/py.py
-      function: _job_py_code_reformat
-    label: reformat py
+      function: _job_py_code_ruff_reformat
+    label: reformat py ruff
     when:
       phase: edit
       tags:
         - py
         - format
         - py format
+        - ruff
 - job:
     addr:
       file: scripts/test_hooks/py.py
@@ -103,6 +114,17 @@
       tags:
         - py
         - lint
+- job:
+    addr:
+      file: scripts/test_hooks/py.py
+      function: _job_py_ruff_lint
+    label: ruff py lint
+    when:
+      phase: analysis
+      tags:
+        - py
+        - lint
+        - ruff
 - job:
     addr:
       file: scripts/test_hooks/py.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,10 @@ runem = ["VERSION"]
 [project.optional-dependencies]
 tests = [
   # This requirements are for development and testing only, not for production.
-  "black==24.10.0",
   "coverage==7.5",
-  "docformatter==1.7.5",
   "flake8-bugbear==24.2.6",
   "flake8==7.0.0",
   "gitchangelog==3.0.4",
-  "isort==5.13.2",
   "mkdocs==1.5.3",
   "mypy==1.9.0",
   "pydocstyle==6.3.0",
@@ -65,6 +62,7 @@ tests = [
   "pytest-profiling==1.7.0",
   "pytest-xdist==3.6.1",
   "pytest==8.3.5",
+  "ruff==0.11.6",
   "setuptools",
   "termplotlib==0.3.9",
   "tox",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,44 @@
+
+# Assume linting/formatting for Python 3.10
+target-version = "py310"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+# 'D" is pydocstyle
+select = [
+  "D",
+  "E4",
+  "E7",
+  "E9",
+  "F",
+  "I",  # sorts imports
+]
+ignore = [
+  "D100", # Missing docstring in public module
+  "D101", # Missing docstring in public class
+  "D102", # Missing docstring in public method
+  "D103", # Missing docstring in public function
+  "D104", # Missing docstring in public package
+  "D106", # Missing docstring in public nested class
+  "D107", # Missing docstring in `__init__`
+
+# FIXME
+  "D205", # 1 blank line required between summary line and description
+  "D415", # First line should end with a period, question mark, or exclamation point
+
+# Review D402 at some point. It errored on a function `def track()` with
+# docstring `"""Track an event using ` which is obviously useful and correct
+  "D402", # First line should not be the function's signature
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+[lint.pydocstyle]
+# Use Google-style docstrings.
+convention = "google"
+
+

--- a/runem/cli/initialise_options.py
+++ b/runem/cli/initialise_options.py
@@ -13,7 +13,6 @@ def initialise_options(
 
     Returns the options dictionary
     """
-
     options: OptionsWritable = InformativeDict(
         {option["name"]: option["default"] for option in config_metadata.options_config}
     )

--- a/runem/command_line.py
+++ b/runem/command_line.py
@@ -43,10 +43,8 @@ def _get_argparse_help_formatter() -> typing.Any:
 
     if use_fixed_width:
         # Use custom formatter with the width specified in the environment variable
-        return (
-            lambda prog: HelpFormatterFixedWidth(  # pylint: disable=unnecessary-lambda
-                prog
-            )
+        return lambda prog: HelpFormatterFixedWidth(  # pylint: disable=unnecessary-lambda
+            prog
         )
 
     # Use default formatter
@@ -383,7 +381,6 @@ def initialise_options(
 
     Returns the options dictionary
     """
-
     options: OptionsWritable = InformativeDict(
         {option["name"]: option["default"] for option in config_metadata.options_config}
     )

--- a/runem/config.py
+++ b/runem/config.py
@@ -46,7 +46,7 @@ def _search_up_multiple_dirs_for_file(
 
 
 def _find_config_file(
-    config_filename: typing.Union[str, pathlib.Path]
+    config_filename: typing.Union[str, pathlib.Path],
 ) -> typing.Tuple[typing.Optional[pathlib.Path], typing.Tuple[pathlib.Path, ...]]:
     """Searches up from the cwd for the given config file-name."""
     start_dirs = (pathlib.Path(".").absolute(),)

--- a/runem/config_parse.py
+++ b/runem/config_parse.py
@@ -162,7 +162,8 @@ def parse_job_config(
             ("cwd" in job["ctx"]) and (job["ctx"]["cwd"] is not None)
         )
         if (not have_ctw_cwd) or isinstance(
-            job["ctx"]["cwd"], str  # type: ignore # handled above
+            job["ctx"]["cwd"],  # type: ignore # handled above
+            str,
         ):
             # if
             # - we don't have a cwd, ctx

--- a/runem/informative_dict.py
+++ b/runem/informative_dict.py
@@ -9,8 +9,7 @@ class InformativeDict(typing.Dict[K, V], typing.Generic[K, V]):
     """A dictionary type that prints out the available keys."""
 
     def __getitem__(self, key: K) -> V:
-        """Attempt to retrieve an item, raising a detailed exception if the key is not
-        found."""
+        """Attempt to get item, raising a detailed exception if the key is not found."""
         try:
             return super().__getitem__(key)
         except KeyError:
@@ -24,19 +23,25 @@ class ReadOnlyInformativeDict(InformativeDict[K, V], typing.Generic[K, V]):
     """A read-only variant of the above."""
 
     def __setitem__(self, key: K, value: V) -> None:
+        """Readonly object, setitem disallowed."""
         raise NotImplementedError("This dictionary is read-only")
 
     def __delitem__(self, key: K) -> None:
+        """Readonly object, delitem disallowed."""
         raise NotImplementedError("This dictionary is read-only")
 
     def pop(self, *args: typing.Any, **kwargs: typing.Any) -> V:
+        """Readonly object, pop disallowed."""
         raise NotImplementedError("This dictionary is read-only")
 
     def popitem(self) -> typing.Tuple[K, V]:
+        """Readonly object, popitem disallowed."""
         raise NotImplementedError("This dictionary is read-only")
 
     def clear(self) -> None:
+        """Readonly object, clear disallowed."""
         raise NotImplementedError("This dictionary is read-only")
 
     def update(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """Readonly object, update disallowed."""
         raise NotImplementedError("This dictionary is read-only")

--- a/runem/job.py
+++ b/runem/job.py
@@ -71,7 +71,6 @@ class Job:
 
         TODO: make a non-static member function
         """
-
         # default to all file-tags
         tags_for_files: typing.Iterable[str] = file_lists.keys()
         use_default_tags: bool = job_tags is None
@@ -91,7 +90,6 @@ class Job:
 
         TODO: make a non-static member function
         """
-
         # First try one of the following keys.
         valid_name_keys = ("label", "command")
         for candidate in valid_name_keys:
@@ -101,6 +99,6 @@ class Job:
 
         # The try the python-wrapper address
         try:
-            return f'{job["addr"]["file"]}.{job["addr"]["function"]}'
+            return f"{job['addr']['file']}.{job['addr']['function']}"
         except KeyError:
             raise NoJobName()  # pylint: disable=raise-missing-from

--- a/runem/job_wrapper_python.py
+++ b/runem/job_wrapper_python.py
@@ -15,7 +15,6 @@ def _load_python_function_from_module(
     function_to_load: str,
 ) -> JobFunction:
     """Given a job-description dynamically loads the test-function so we can call it."""
-
     # first locate the module relative to the config file
     abs_module_file_path: pathlib.Path = (
         cfg_filepath.parent / module_file_path
@@ -109,9 +108,9 @@ def get_job_wrapper_py_func(
         ) from err
 
     anchored_file_path = cfg_filepath.parent / module_file_path
-    assert (
-        anchored_file_path.exists()
-    ), f"{module_file_path} not found at {anchored_file_path}!"
+    assert anchored_file_path.exists(), (
+        f"{module_file_path} not found at {anchored_file_path}!"
+    )
 
     module_name = module_file_path.stem.replace(" ", "_").replace("-", "_")
 

--- a/runem/report.py
+++ b/runem/report.py
@@ -46,12 +46,13 @@ def replace_bar_graph_characters(text: str, end_str: str, replace_char: str) -> 
     """Replaces block characters in lines containing `end_str` with give char.
 
     Args:
-        text_lines (List[str]): A list of strings, each representing a line of text.
+        text (str): Text containing lines of bar-graphs (perhaps)
+        end_str (str): If contained by a line, the bar-graph shapes are replaced.
         replace_char (str): The character to replace all bocks with
 
     Returns:
-        List[str]: The modified list of strings with block characters replaced
-                   on specified lines.
+        str: The modified `text` with block characters replaced on specific
+             lines.
     """
     # Define the block character and its light shade replacement
     block_chars = (

--- a/runem/run_command.py
+++ b/runem/run_command.py
@@ -41,9 +41,7 @@ RecordSubJobTimeType = typing.Callable[[str, timedelta], None]
 
 
 def parse_stdout(stdout: str, prefix: str) -> str:
-    """Prefixes each line of the output with a given label, except trailing new
-    lines."""
-
+    """Prefixes each line of output with a given label, except trailing new lines."""
     # Edge case: Return the prefix immediately for an empty string
     if not stdout:
         return prefix

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -19,6 +19,7 @@ We do:
 - time tests and tell you what used the most time, and how much time run-tests saved
   you
 """
+
 import contextlib
 import multiprocessing
 import os
@@ -68,7 +69,6 @@ def _determine_run_parameters(argv: typing.List[str]) -> ConfigMetadata:
 
     Return a ConfigMetadata object with all the required information.
     """
-
     # Because we want to be able to show logging whilst parsing .runem.yml config, we
     # need to check the state of the logging-verbosity switches here, manually, as well.
     verbose = "--verbose" in argv
@@ -105,13 +105,14 @@ def _update_progress(
     """Updates progress report periodically for running tasks.
 
     Args:
-        label (str): The identifier.
+        phase (str): The currently running phase.
         running_jobs (Dict[str, str]): The currently running jobs.
+        completed_jobs (Dict[str, str]): The jobs that have finished work.
         all_jobs (Jobs): All jobs, encompassing both completed and running jobs.
         is_running (ValueProxy[bool]): Flag indicating if jobs are still running.
         num_workers (int): Indicates the number of workers performing the jobs.
+        show_spinner (bool): Whether to show the animated spinner or not.
     """
-
     last_running_jobs_set: typing.Set[str] = set()
 
     # Using the `rich` module to show a loading spinner on console
@@ -132,7 +133,8 @@ def _update_progress(
                 "blue",
             )  # Reflect current running jobs accurately
             report: str = (
-                f"[green]{phase}[/green]: {progress}({num_workers}): {running_jobs_list}"
+                f"[green]{phase}[/green]: {progress}({num_workers}): "
+                f"{running_jobs_list}"
             )
             if show_spinner:
                 assert isinstance(spinner_ctx, Status)

--- a/runem/types/hooks.py
+++ b/runem/types/hooks.py
@@ -4,7 +4,7 @@ import enum
 class HookName(enum.Enum):
     """List supported hooks.
 
-    TODO:
+    Todo:
     - before all tasks are run, after config is read
     - BEFORE_ALL = "before-all"
     - after all tasks are done, before reporting

--- a/runem/types/types_jobs.py
+++ b/runem/types/types_jobs.py
@@ -1,28 +1,25 @@
-"""
+"""Job‑typing helpers.
 
-Some note on Unpack and kwargs:
-    We *try* to strongly type `**kwargs` for clarity.
-    We have tried several ways to define a Generic type that encapsulates
-        `**kwargs: SingleType`
-    ... but none of the solutions worked with python 3.9 -> 3.12 and mypy 1.9.0,
-    so we have to recommend instead using:
-        `**kwargs: Unpack[KwArgsType]`
+Cross‑version advice
+--------------------
+* Type variadic keyword arguments as **kwargs: Unpack[KwArgsT] for clarity.
+* Always import Unpack from ``typing_extensions``.
+  - Std‑lib Unpack appears only in Py 3.12+.
+  - ``typing_extensions`` works on 3.9‑3.12, so one import path keeps
+    mypy/pyright happy without conditional logic.
 
-    For this to work across versions of python where support for Unpack changes;
-    for example `Unpack` is a python 3.12 feature, but available in the
-    `typing_extensions` module.
+Example:
+~~~~~~~
+from typing_extensions import TypedDict, Unpack
 
-    So, for now, it looks like we get away with importing `Unpack` from the
-    `typing_extensions` module, even in python 3.12, so we will use, and
-    recommend using, the `typing_extensions` of `Unpack`, until it becomes
-    obsolete.
 
-    Alternatively, we can use the following, but it's unnecessarily verbose.
+class SaveKwArgs(TypedDict):
+    path: str
+    overwrite: bool
 
-    if sys.version_info >= (3, 12):  # pragma: no coverage
-        from typing import Unpack
-    else:  # pragma: no coverage
-        from typing_extensions import Unpack
+
+def save_job(**kwargs: Unpack[SaveKwArgs]) -> None:
+    ...
 """
 
 import pathlib

--- a/scripts/test_hooks/py.py
+++ b/scripts/test_hooks/py.py
@@ -9,7 +9,69 @@ from runem.run_command import RunCommandUnhandledError, run_command
 from runem.types import FilePathList, JobKwargs, JobName, JobReturnData, Options
 
 
-def _job_py_code_reformat(
+def _job_py_code_ruff_reformat(
+    **kwargs: typing.Any,
+) -> None:
+    """Runs python formatting code in serial order as one influences the other."""
+    label: JobName = kwargs["label"]
+    options: Options = kwargs["options"]
+    python_files: FilePathList = kwargs["file_list"]
+
+    # put into 'check' mode if requested on the command line
+    extra_args = []
+    if options["check-only"]:
+        extra_args.append("--check")
+
+    if not options["ruff"]:
+        # Do not run `ruff` if opted-out
+        return
+
+    # If ruff is enabled we do NOT run black etc. because ruff does that
+    # for us, faster and better.
+    ruff_format_cmd = [
+        "python3",
+        "-m",
+        "ruff",
+        "format",
+        *extra_args,
+        *python_files,
+    ]
+    kwargs["label"] = f"{label} ruff"
+    run_command(cmd=ruff_format_cmd, **kwargs)
+
+
+def _job_py_ruff_lint(
+    **kwargs: typing.Any,
+) -> None:
+    """Runs python formatting code in serial order as one influences the other."""
+    label: JobName = kwargs["label"]
+    options: Options = kwargs["options"]
+    python_files: FilePathList = kwargs["file_list"]
+
+    # try to auto-fix issues (one benefit of ruff over flake8 etc.)
+    extra_args = []
+    if options["fix"]:
+        extra_args.append("--fix")
+
+    if not options["ruff"]:
+        # Do not run `ruff` if opted-out
+        return
+
+    # If ruff is enabled we do NOT run black etc. because ruff does that
+    # for us, faster and better.
+    ruff_lint_cmd = [
+        "python3",
+        "-m",
+        "ruff",
+        "check",
+        *extra_args,
+        *python_files,
+    ]
+    kwargs["label"] = f"{label} ruff"
+    run_command(cmd=ruff_lint_cmd, **kwargs)
+
+
+def _job_py_code_reformat_deprecated(
     **kwargs: Unpack[JobKwargs],
 ) -> None:
     """Runs python formatting code in serial order as one influences the other."""

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -110,9 +110,9 @@ def test_find_files_basic(
     )
     results: FilePathListLookup = find_files(config_metadata)
     if check_modified_files and check_head_files:
-        assert (
-            mock_subprocess_check_output.call_count == 3
-        ), "twice for modified, once for head"
+        assert mock_subprocess_check_output.call_count == 3, (
+            "twice for modified, once for head"
+        )
         assert results == {
             "dummy tag": [file_strings[0]]  # we filter in only the *1* files.
         }

--- a/tests/test_hook_manager.py
+++ b/tests/test_hook_manager.py
@@ -57,7 +57,6 @@ def test_register_hook(hook_man: HookManager) -> None:
 )
 def test_deregister_hook(verbosity: bool, hook_man: HookManager) -> None:
     """Test deregistering a hook function."""
-
     # run the command and capture output
     with io.StringIO() as buf, redirect_stdout(buf):
         hook_man.register_hook(HookName.ON_EXIT, mock_hook_function, verbose=verbosity)
@@ -182,7 +181,9 @@ def test_register_non_existent_hook(hook_man: HookManager) -> None:
     """Test error handling for registering a non-existent hook."""
     with pytest.raises(ValueError) as e:
         hook_man.register_hook(
-            "non_existent_hook", mock_hook_function, verbose=False  # type: ignore
+            "non_existent_hook",  # type: ignore
+            mock_hook_function,
+            verbose=False,
         )
     assert "Hook non_existent_hook does not exist" in str(e.value)
 

--- a/tests/test_informative_dict.py
+++ b/tests/test_informative_dict.py
@@ -16,9 +16,9 @@ def sample_dict_fixture() -> InformativeDict[str, int]:
 
 
 def test_getitem_existing_key(sample_dict: InformativeDict[str, int]) -> None:
-    assert (
-        sample_dict["one"] == 1
-    ), "Should retrieve the correct value for an existing key"
+    assert sample_dict["one"] == 1, (
+        "Should retrieve the correct value for an existing key"
+    )
 
 
 def test_getitem_non_existent_key(sample_dict: InformativeDict[str, int]) -> None:
@@ -40,33 +40,34 @@ def test_iteration(sample_dict: InformativeDict[str, int]) -> None:
 
 def test_initialization_with_items() -> None:
     dict_init = InformativeDict({"a": 1, "b": 2})
-    assert (
-        dict_init["a"] == 1 and dict_init["b"] == 2
-    ), "Should correctly initialize with given items"
+    assert dict_init["a"] == 1 and dict_init["b"] == 2, (
+        "Should correctly initialize with given items"
+    )
 
 
 def test_read_only_get_existing_key() -> None:
-    """Test that accessing an existing key in ReadOnlyInformativeDict returns the
-    correct value."""
+    """Tests accessing valid ReadOnlyInformativeDict key returns correct value."""
     ro_dict = ReadOnlyInformativeDict[str, str]({"existing_key": "value"})
-    assert (
-        ro_dict["existing_key"] == "value"
-    ), "Failed to retrieve the value for an existing key."
+    assert ro_dict["existing_key"] == "value", (
+        "Failed to retrieve the value for an existing key."
+    )
 
 
 def test_read_only_get_non_existent_key() -> None:
-    """Test that attempting to access a non-existent key in ReadOnlyInformativeDict
-    raises a KeyError, and the error message includes the missing key and lists
-    available keys."""
+    """Tests attempted access of non-existent ReadOnlyInformativeDict key raises.
+
+    It should raise a KeyError, and the error message includes the missing key and lists
+    available keys.
+    """
     ro_dict = ReadOnlyInformativeDict[str, str]({"existing_key": "value"})
     with pytest.raises(KeyError) as exc_info:
         _ = ro_dict["non_existent_key"]
-    assert "non_existent_key" in str(
-        exc_info.value
-    ), "The exception message does not mention the missing key."
-    assert "existing_key" in str(
-        exc_info.value
-    ), "The exception message does not list available keys."
+    assert "non_existent_key" in str(exc_info.value), (
+        "The exception message does not mention the missing key."
+    )
+    assert "existing_key" in str(exc_info.value), (
+        "The exception message does not list available keys."
+    )
 
 
 # Define the operation type with concrete types for this test

--- a/tests/test_job_filter.py
+++ b/tests/test_job_filter.py
@@ -24,7 +24,6 @@ from runem.types.runem_config import JobConfig, PhaseGroupedJobs
 )
 def test_runem_job_filters_work_with_no_tags(verbosity: bool) -> None:
     """TODO."""
-
     config_file_path = pathlib.Path(__file__).parent / ".runem.yml"
     expected_job: JobConfig = {
         "addr": {
@@ -95,7 +94,6 @@ def test_should_filter_out_by_tags_with_tags_to_avoid(verbosity: bool) -> None:
        presence of avoided tags.
     2. That the verbosity of the output matches the expected verbosity level.
     """
-
     # Set up a job configuration with specific tags.
     job: JobConfig = {
         "label": "Job1",  # Job identifier.

--- a/tests/test_job_runner_simple_command.py
+++ b/tests/test_job_runner_simple_command.py
@@ -110,7 +110,8 @@ def test_job_runner_simple_command_with_file_list(mock_run_command: Mock) -> Non
 def test_job_runner_simple_command_with_option(mock_run_command: Mock) -> None:
     """Tests that option-passing to jobs, pass --option_on but not --option_off."""
     test_cmd_string: str = (
-        'echo "some option before switch" {option_on} {option_off} "some option after switch"'
+        'echo "some option before switch" {option_on} '
+        '{option_off} "some option after switch"'
     )
     job_config: JobConfig = {
         "command": test_cmd_string,

--- a/tests/test_job_wrapper.py
+++ b/tests/test_job_wrapper.py
@@ -6,9 +6,8 @@ from runem.job_wrapper import get_job_wrapper
 from runem.types.runem_config import JobConfig
 from runem.types.types_jobs import JobFunction
 
-DUMMY_FUNCTION: JobFunction = (
-    "intentionally bad type as string to test call"  # type: ignore[assignment]
-)
+# use a string as a ad type to test call
+DUMMY_FUNCTION: JobFunction = "intentionally bad type"  # type: ignore[assignment]
 
 
 @patch(

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -32,6 +32,7 @@ class MockPopen:
         exc_val: Optional[BaseException],
         exc_tb: Optional[Type[BaseException]],
     ) -> None:
+        """Do nothing in the context on exit."""
         pass
 
     def wait(self) -> int:
@@ -103,7 +104,6 @@ def test_run_command_basic_call(mock_popen: Mock) -> None:
 @patch("runem.run_command.Popen", autospec=True, return_value=MockPopen())
 def test_run_command_basic_call_verbose(mock_popen: Mock) -> None:
     """Test that we get extra output when the verbose flag is set."""
-
     # capture any prints the run_command() does, should be informative in verbose=True mode
     with io.StringIO() as buf, redirect_stdout(buf):
         raw_output = runem.run_command.run_command(
@@ -178,9 +178,9 @@ def test_run_command_ignore_fails_skips_failures_for_non_zero_exit_code(
             verbose=False,
             ignore_fails=True,
         )
-        assert (
-            output == ""
-        ), "expected empty output on failed run with 'ignore_fails=True'"
+        assert output == "", (
+            "expected empty output on failed run with 'ignore_fails=True'"
+        )
 
         run_command_stdout = buf.getvalue()
 
@@ -208,9 +208,9 @@ def test_run_command_ignore_fails_skips_no_side_effects_on_success(
             verbose=False,
             ignore_fails=True,
         )
-        assert (
-            output == "test output"
-        ), "expected empty output on failed run with 'ignore_fails=True'"
+        assert output == "test output", (
+            "expected empty output on failed run with 'ignore_fails=True'"
+        )
 
         run_command_stdout = buf.getvalue()
 
@@ -239,9 +239,9 @@ def test_run_command_ignore_fails_skips_no_side_effects_on_success_with_valid_ex
             valid_exit_ids=(3,),  # matches patch value for 'returncode' above
             ignore_fails=True,
         )
-        assert (
-            output == "test output"
-        ), "expected empty output on failed run with 'ignore_fails=True'"
+        assert output == "test output", (
+            "expected empty output on failed run with 'ignore_fails=True'"
+        )
 
         run_command_stdout = buf.getvalue()
 
@@ -396,7 +396,6 @@ def test_run_command_with_env_on_error(mock_popen: Mock) -> None:
 @patch("runem.run_command.Popen", autospec=True, return_value=MockPopen())
 def test_run_command_basic_call_verbose_with_cwd(mock_popen: Mock) -> None:
     """Test that we get extra output when the verbose flag is set."""
-
     # capture any prints the run_command() does, should be informative in verbose=True mode
     with io.StringIO() as buf, redirect_stdout(buf):
         raw_output = runem.run_command.run_command(

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -49,12 +49,11 @@ DIR_REPLACEMENT_DIR: str = "[TEST_REPLACED_DIR]"
 def replace_max_cores(stdout: str) -> str:
     """Replace instances of '(of X max)' with '(of [NUM CORES] max)' in a given string.
 
-    Args:
-    s (str): The original string containing '(of X max)' patterns.
-    num_cores (int): The number of cores to insert into the replacement string.
+    Params:
+        stdout (str): The stdout to have the non-deterministic 'cores' output replaced.
 
     Returns:
-    str: Modified string with '(of X max)' replaced by '(of [NUM CORES] max)'.
+        str: Modified string with '(of X max)' replaced by '(of [NUM CORES] max)'.
     """
     return re.sub(r"\(of \d+ max\)", "(of [NUM CORES] max)", stdout)
 
@@ -414,7 +413,6 @@ def test_runem_with_full_config(verbosity: bool, silent: bool) -> None:
 
     if not verbosity:
         if silent:
-
             assert runem_stdout == [
                 (
                     "runem: Running 'dummy phase 1' with 2 workers (of [NUM CORES] max) "
@@ -1566,15 +1564,18 @@ def test_runem_tag_out_filters_work_all_tags(verbosity: bool) -> None:
             "runem: No jobs for phase 'dummy phase 2' tags ",
         ]
     else:
-        assert runem_stdout == [
-            # "runem: found 1 batches, 1 'mock phase' files, ",
-            # (
-            #     "runem: excluding jobs with tags 'dummy tag 1', 'dummy tag 2', "
-            #     "'tag only on job 1', 'tag only on job 2'"
-            # ),
-            # "runem: No jobs for phase 'dummy phase 1' tags ",
-            # "runem: No jobs for phase 'dummy phase 2' tags ",
-        ]
+        assert (
+            runem_stdout
+            == [
+                # "runem: found 1 batches, 1 'mock phase' files, ",
+                # (
+                #     "runem: excluding jobs with tags 'dummy tag 1', 'dummy tag 2', "
+                #     "'tag only on job 1', 'tag only on job 2'"
+                # ),
+                # "runem: No jobs for phase 'dummy phase 1' tags ",
+                # "runem: No jobs for phase 'dummy phase 2' tags ",
+            ]
+        )
 
 
 @pytest.mark.parametrize(
@@ -1744,7 +1745,7 @@ def test_progress_updater_with_running_jobs_and_10_jobs(mock_sleep: Mock) -> Non
     all_jobs: Jobs = []
     for idx in range(10):
         job_config = copy.copy(job_config)
-        job_config["label"] = f'{job_config["label"]} {idx}'
+        job_config["label"] = f"{job_config['label']} {idx}"
         all_jobs.append(job_config)
     with pytest.raises(SleepCalledError), multiprocessing.Manager() as manager:
         _update_progress(


### PR DESCRIPTION
### Summary :memo:

Ports over to using `ruff` instead of black, isort, etc.

### Details

`ruff` is very fast for most of the things that runem uses for its own dev-ops jobs, faster that other things.
