### PR TITLE
Feat/no runem traceback on job fail

### DIFF
--- a/runem/job_execute.py
+++ b/runem/job_execute.py
@@ -132,12 +132,15 @@ def job_execute(
     """
     this_id: str = str(uuid.uuid4())
     running_jobs[this_id] = Job.get_job_name(job_config)
-    results = job_execute_inner(
-        job_config,
-        config_metadata,
-        file_lists,
-        **kwargs,
-    )
-    completed_jobs[this_id] = running_jobs[this_id]
-    del running_jobs[this_id]
+    try:
+        results = job_execute_inner(
+            job_config,
+            config_metadata,
+            file_lists,
+            **kwargs,
+        )
+    finally:
+        # Always tidy-up job statuses
+        completed_jobs[this_id] = running_jobs[this_id]
+        del running_jobs[this_id]
     return results

--- a/runem/run_command.py
+++ b/runem/run_command.py
@@ -204,7 +204,7 @@ def run_command(  # noqa: C901
         error_string = (
             f"runem: [red bold]FATAL[/red bold]: command failed: [blue]{label}[/blue]"
             f"\n\t[yellow]{env_overrides_as_string}{cmd_string}[/yellow]"
-            f"\n[red underline]| ERROR[/red underline]"
+            f"\n[red underline]| ERROR[/red underline]: [blue]{label}[/blue]"
             f"\n{str(parsed_stdout)}"
             f"\n[red underline]| ERROR END[/red underline]"
         )

--- a/runem/runem.py
+++ b/runem/runem.py
@@ -49,6 +49,7 @@ from runem.log import error, log, warn
 from runem.report import report_on_run
 from runem.run_command import RunemJobError
 from runem.types.common import OrderedPhases, PhaseName
+from runem.types.errors import SystemExitBad
 from runem.types.filters import FilePathListLookup
 from runem.types.hooks import HookName
 from runem.types.runem_config import Config, Jobs, PhaseGroupedJobs
@@ -373,7 +374,7 @@ def timed_main(argv: typing.List[str]) -> None:
         # we got a failure somewhere, now that we've reported the timings we
         # re-raise.
         error(failure_exception.stdout)
-        raise failure_exception
+        raise SystemExitBad(1) from failure_exception
 
 
 if __name__ == "__main__":

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -27,6 +27,7 @@ from runem.runem import (
     _update_progress,
     timed_main,
 )
+from runem.types.errors import SystemExitBad
 from runem.types.filters import FilePathListLookup
 from runem.types.hooks import HookName
 from runem.types.runem_config import (
@@ -1857,7 +1858,7 @@ DUMMY_MAIN_RETURN: MainReturnType = (
 def test_runem_re_raises_after_reporting(
     main_mock: Mock,
 ) -> None:
-    with pytest.raises(IntentionalTestError):
+    with pytest.raises(SystemExitBad):
         timed_main([])
 
 


### PR DESCRIPTION
### Summary :memo:

Makes runem errors MUCH more useful

### Details

Primarily by not showing the traceback pointing at runem code, instead just showing the error log that the job recevied.
