### PR TITLE
fix(log-wrapping): fixes log wrapping so it does not truncate

### DIFF
--- a/runem/blocking_print.py
+++ b/runem/blocking_print.py
@@ -21,6 +21,9 @@ def _reset_console() -> Console:
         # `highlight` is what colourises string and number in print() calls.
         # We do not want this to be auto-magic.
         highlight=False,
+        # `soft_wrap=True` disables word-wrap & cropping by default:
+        #  - `soft_wrap` reads like a misnomer to me
+        soft_wrap=True,
     )
     return RICH_CONSOLE
 


### PR DESCRIPTION
### Summary :memo:

Fixes log wrapping so it does not truncate

### Details

I used printing of multiple variants to find this switch. This happened because `soft_wrap=True` implies that it is turning on a line-break or similar system *instead of* turning off hard-wrapping, so it should be `hard_wrap=False` or similar.

