### PR TITLE
chore(ruff-target): updates the ruff python target 310->312

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 
 # Assume linting/formatting for Python 3.10
-target-version = "py310"
+target-version = "py312"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.


### PR DESCRIPTION
### Summary :memo:

Just bring the ruff-target up to match the dev-version

