### PR TITLE
Feat/dot notation module lookup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,9 +99,42 @@ command: bash scripts/build_wrapper.sh
 ```yaml
 command: clang-tidy -checks='*' -fix -header-filter='.*' your_file.cpp
 ```
+### job.module
+```yml
+module: python.import.dot.notation.file_name.runem_function
+```
+A fully qualified python-import-path to a runem function - see below for an example of a Job Function.
+
+Similar to `addr`, "module" imports the function at the given location. Whilst `addr` uses a filepath and a function name, `module` uses a python dot-notation path to import a function. That function is then, at execution time, called with the context's `kwargs` - see below for an example of a Job Function.
+
+`.runem.yml` file-path and that is used for the `cwd`, **not** the cwd parameter in the config (PRs welcome). context for the import, and the PYTHONPATH will be used. The function receives all information needed to run the job, including `label`, `JobConfig`, `verbose`, `options` and other run-time context.
+
+**Example:**
+
+```yaml
+module: scripts.test_hooks.fastlane.run_fastlane_build
+```
+
+#### Gotchas and Troubleshooting `job.module`
+##### Gotchas
+`module` jobs uses python's inbuilt `importlib` to grab and validate the import-path.
+
+This mean that standard python import rules apply. Consider that: 
+
+- any `PYTHONPATH`, `PATH`, `sys.path` dirs will be respected by the python runtime that is running `runem`.
+- for module-path `path.to.job.func`, you would expect the `.runem.yml` to be next to the `path/` directory.
+- for module-path `dir1.dir2.job_file.func` there should be `__init__.py` files in each of the directories in that path i.e. `dir1/__init__.py` and `dir2/__init__.py`.
+- executing `runem` from the common root path, that is, the path that `.runem.yml` is in.
+
+It is easiest to think of the import root as being relative to the PWD when running runem, so jobs that use `module` may break when running `runem` from other subdirs in the directory tree.
+
+##### Verifying `module` address is correct
+If `python3 -c "import my.module.runem_func"` works then `module: my.module.runem_func` _should_ also work.
 
 ### job.addr:
 Specifies where a stand-alone python function can be found by `runem`.
+
+This can be a more stable version of `job.module`, depending on use-case.
 
 The address is a combination of `file` (path) and `function` (name), pointing at a callable-like object/function - see below for an example of a Job Function.
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -79,6 +79,14 @@ Here's a simple setup for a python project.
         - py
         - format
         - py format
+- job:
+    module: runem_hooks.py._some_runem_function
+    label: some other task
+    when:
+      phase: analysis
+      tags:
+        - py
+        - other
 ```
 
 Notice that this specifies:

--- a/runem/job_runner_module_func_path.py
+++ b/runem/job_runner_module_func_path.py
@@ -1,0 +1,82 @@
+import importlib
+import pathlib
+
+from runem.types.errors import FunctionNotFound
+from runem.types.runem_config import JobWrapper
+from runem.types.types_jobs import JobFunction
+
+
+def _load_python_function_from_dotted_path(
+    cfg_filepath: pathlib.Path,
+    module_func_path: str,
+) -> JobFunction:
+    """Load a Python function given a dotted path like 'pkg.module.func'.
+
+    Args:
+            cfg_filepath: Path to the config file (used only for clearer error messages).
+            module_func_path: Dotted path to the target function, e.g. 'a.b.c.my_func'.
+
+    Returns:
+            The imported callable.
+
+    Raises:
+            FunctionNotFound: If the module cannot be imported or the attribute is
+                              missing/not callable.
+    z
+        Example:
+            >>> fn = _load_python_function_from_dotted_path(Path('cfg.yml'), 'my_mod.tasks.run')
+            >>> fn()  # call it
+    """
+    mod_path, sep, func_name = module_func_path.rpartition(".")
+    if not sep or not mod_path or not func_name:
+        raise FunctionNotFound(
+            f"Invalid dotted path '{module_func_path}'. Expected format 'pkg.module.func'. "
+            f"Check your config at '{cfg_filepath}'."
+        )
+
+    try:
+        module = importlib.import_module(mod_path)
+    except Exception as err:  # pylint: disable=broad-except
+        raise FunctionNotFound(
+            f"Unable to import module '{mod_path}' from dotted path '{module_func_path}'. "
+            f"Check PYTHONPATH and installed packages; config at '{cfg_filepath}'."
+        ) from err
+
+    try:
+        func: JobFunction = getattr(module, func_name)
+    except AttributeError as err:
+        raise FunctionNotFound(
+            f"Function '{func_name}' not found in module '{mod_path}'. "
+            f"Confirm it exists and is exported; config '{cfg_filepath}'."
+        ) from err
+
+    if not callable(func):
+        raise FunctionNotFound(
+            f"Attribute '{func_name}' in module '{mod_path}' is not callable. "
+            f"Update your config '{cfg_filepath}' to reference a function."
+        )
+    return func
+
+
+def get_job_wrapper_py_module_dot_path(
+    job_wrapper: JobWrapper,
+    cfg_filepath: pathlib.Path,
+) -> JobFunction:
+    """For a job, dynamically loads the associated python job-function.
+
+    Side-effects: also re-addressed the job-config.
+    """
+    function_path_to_load: str = job_wrapper["module"]
+    try:
+        function: JobFunction = _load_python_function_from_dotted_path(
+            cfg_filepath, function_path_to_load
+        )
+    except FunctionNotFound as err:
+        raise FunctionNotFound(
+            (
+                "runem failed to find "
+                f"job.module '{job_wrapper['module']}' from '{cfg_filepath}'"
+            )
+        ) from err
+
+    return function

--- a/runem/job_wrapper.py
+++ b/runem/job_wrapper.py
@@ -1,5 +1,6 @@
 import pathlib
 
+from runem.job_runner_module_func_path import get_job_wrapper_py_module_dot_path
 from runem.job_runner_simple_command import (
     job_runner_simple_command,
     validate_simple_command,
@@ -20,6 +21,12 @@ def get_job_wrapper(job_wrapper: JobWrapper, cfg_filepath: pathlib.Path) -> JobF
         command_string: str = job_wrapper["command"]
         validate_simple_command(command_string)
         return job_runner_simple_command
+
+    if "module" in job_wrapper:
+        # validate that the command is "understandable" and usable.
+        module_path: str = job_wrapper["module"]
+        validate_simple_command(module_path)
+        return get_job_wrapper_py_module_dot_path(job_wrapper, cfg_filepath)
 
     # if we do not have a simple command address assume we have just an addressed
     # function

--- a/runem/job_wrapper_python.py
+++ b/runem/job_wrapper_python.py
@@ -114,7 +114,7 @@ def get_job_wrapper_py_func(
 
     module_name = module_file_path.stem.replace(" ", "_").replace("-", "_")
 
-    function = _load_python_function_from_module(
+    function: JobFunction = _load_python_function_from_module(
         cfg_filepath, module_name, module_file_path, function_to_load
     )
 

--- a/runem/schema.yml
+++ b/runem/schema.yml
@@ -100,23 +100,23 @@ $defs:
     properties:
       hook_name: { type: string, minLength: 1 }
       addr:      { $ref: "#/$defs/addr" }
-      command: { type: string, minLength: 1 }
+      command:   { type: string, minLength: 1 }
+      module :   { type: string, minLength: 1 }
 
   job:
     type: object
-    oneOf:
-      - required: [command]
-      - required: [addr]
     additionalProperties: false
     properties:
       label:   { type: string, minLength: 1 }
       addr:    { $ref: "#/$defs/addr" }
       command: { type: string, minLength: 1 }
-      ctx:    { $ref: "#/$defs/ctx" }
+      module : { type: string, minLength: 1 }
+      ctx:     { $ref: "#/$defs/ctx" }
       when:    { $ref: "#/$defs/when" }
     oneOf:
-      - required: [addr]    # either addr
-      - required: [command] # or command, but not both
+      - required: [addr]    # one of addr
+      - required: [command] # or command
+      - required: [module]  # or module, but not more than one
     not:
       anyOf:
         - required: [addr, command]   # forbid both together

--- a/runem/types/runem_config.py
+++ b/runem/types/runem_config.py
@@ -63,6 +63,7 @@ class JobWrapper(typing.TypedDict, total=False):
 
     addr: JobAddressConfig  # which callable to call
     command: str  # a one-liner command to be run
+    module: str  # a module-path for a job-function, like `addr` but simpler
 
 
 class JobConfig(JobWrapper, total=False):

--- a/tests/test_job_runner_module_func_path.py
+++ b/tests/test_job_runner_module_func_path.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+
 import io
+import types
 from contextlib import redirect_stdout
 from pathlib import Path
+from typing import Any
 
+import pytest
 from typing_extensions import Unpack
 
 from runem.job_runner_module_func_path import (
     _load_python_function_from_dotted_path,
+    get_job_wrapper_py_module_dot_path,
 )
+from runem.types.errors import FunctionNotFound
+from runem.types.runem_config import JobWrapper
 from runem.types.types_jobs import JobFunction, JobKwargs
 from tests.utils.dummy_data import DUMMY_JOB_K_ARGS
 
@@ -18,12 +26,18 @@ def dummy_job_function_no_params(**kwargs: Unpack[JobKwargs]) -> None:
     print("dummy job function no params")
 
 
+# ---------- Positive paths ----------
+
+
 def test_load_function_success() -> None:
     """Loads a real callable from this test module."""
     func: JobFunction = _load_python_function_from_dotted_path(
         cfg_filepath=Path(__file__),
         module_func_path=f"{DOT_PATH_THIS_FILE}.dummy_job_function_no_params",
     )
+    assert callable(func)
+    assert func is dummy_job_function_no_params  # type: ignore[comparison-overlap]
+
     with io.StringIO() as buf, redirect_stdout(buf):
         func(**DUMMY_JOB_K_ARGS)
         stdout: str = buf.getvalue()
@@ -32,3 +46,120 @@ def test_load_function_success() -> None:
         "dummy job function no params",
         "",
     ]
+
+
+def test_get_job_wrapper_success() -> None:
+    """get_job_wrapper_py_module_dot_path returns the same callable on success."""
+    job_wrapper: JobWrapper = {
+        "module": f"{DOT_PATH_THIS_FILE}.dummy_job_function_no_params"
+    }
+    func: JobFunction = get_job_wrapper_py_module_dot_path(
+        job_wrapper=job_wrapper,
+        cfg_filepath=Path(__file__),
+    )
+    assert func is dummy_job_function_no_params  # type: ignore[comparison-overlap]
+
+    with io.StringIO() as buf, redirect_stdout(buf):
+        func(**DUMMY_JOB_K_ARGS)
+        stdout: str = buf.getvalue()
+    stdout_lines = stdout.split("\n")
+    assert stdout_lines == [
+        "dummy job function no params",
+        "",
+    ]
+
+
+# ---------- Invalid dotted path variants ----------
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "",  # empty
+        "abc",  # no dot separator
+        "abc.",  # missing function name
+        ".func",  # missing module path
+    ],
+)
+def test_invalid_dotted_path_raises(bad_path: str) -> None:
+    """Invalid dotted strings are rejected early with FunctionNotFound."""
+    with pytest.raises(FunctionNotFound) as ei:
+        _ = _load_python_function_from_dotted_path(
+            cfg_filepath=Path("cfg.yml"),
+            module_func_path=bad_path,
+        )
+    # Helpful, deterministic message (keeps stoic clarity for users)
+    assert "Invalid dotted path" in str(ei.value)
+
+
+# ---------- Import failure (module cannot be imported) ----------
+
+
+def test_import_failure_wraps_as_function_not_found() -> None:
+    """Non-existent module should bubble up as FunctionNotFound with context."""
+    with pytest.raises(FunctionNotFound) as ei:
+        _ = _load_python_function_from_dotted_path(
+            cfg_filepath=Path("cfg.yml"),
+            module_func_path="this.module.does.not.exist.func",
+        )
+    assert "Unable to import module" in str(ei.value)
+
+
+# ---------- Attribute missing on imported module ----------
+
+
+def test_attribute_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Module imports, but attribute is absent -> FunctionNotFound."""
+    mod_name = "tmp_attr_missing_mod"
+    module = types.ModuleType(mod_name)
+    monkeypatch.setitem(__import__("sys").modules, mod_name, module)
+
+    with pytest.raises(FunctionNotFound) as ei:
+        _ = _load_python_function_from_dotted_path(
+            cfg_filepath=Path("cfg.yml"),
+            module_func_path=f"{mod_name}.nope",
+        )
+    assert "Function 'nope' not found" in str(ei.value)
+
+
+# ---------- Attribute exists but is not callable ----------
+
+
+def test_attribute_not_callable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Module has the attribute, but it's not callable -> FunctionNotFound."""
+    mod_name = "tmp_not_callable_mod"
+    module = types.ModuleType(mod_name)
+    module.not_callable: Any = 123  # type: ignore[attr-defined,misc]
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        mod_name,
+        module,
+    )
+
+    with pytest.raises(FunctionNotFound) as ei:
+        _ = _load_python_function_from_dotted_path(
+            cfg_filepath=Path("cfg.yml"),
+            module_func_path=f"{mod_name}.not_callable",
+        )
+    assert "is not callable" in str(ei.value)
+
+
+# ---------- Wrapper re-raises with runem-flavoured message ----------
+
+
+def test_get_job_wrapper_rewraps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wrapper should reword FunctionNotFound with job.module context."""
+    mod_name = "tmp_wrapper_bad"
+    # Ensure the module is truly absent so import fails
+    sys_mods = __import__("sys").modules
+    sys_mods.pop(mod_name, None)
+
+    job_wrapper: JobWrapper = {"module": f"{mod_name}.missing"}
+    with pytest.raises(FunctionNotFound) as ei:
+        get_job_wrapper_py_module_dot_path(
+            job_wrapper=job_wrapper,
+            cfg_filepath=Path("cfg.yml"),
+        )
+    msg = str(ei.value)
+    assert "runem failed to find job.module" in msg
+    assert f"'{job_wrapper['module']}'" in msg

--- a/tests/test_job_runner_module_func_path.py
+++ b/tests/test_job_runner_module_func_path.py
@@ -1,0 +1,34 @@
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from typing_extensions import Unpack
+
+from runem.job_runner_module_func_path import (
+    _load_python_function_from_dotted_path,
+)
+from runem.types.types_jobs import JobFunction, JobKwargs
+from tests.utils.dummy_data import DUMMY_JOB_K_ARGS
+
+DOT_PATH_THIS_FILE = "tests.test_job_runner_module_func_path"
+
+
+def dummy_job_function_no_params(**kwargs: Unpack[JobKwargs]) -> None:
+    """A simple callable used for positive-path testing."""
+    print("dummy job function no params")
+
+
+def test_load_function_success() -> None:
+    """Loads a real callable from this test module."""
+    func: JobFunction = _load_python_function_from_dotted_path(
+        cfg_filepath=Path(__file__),
+        module_func_path=f"{DOT_PATH_THIS_FILE}.dummy_job_function_no_params",
+    )
+    with io.StringIO() as buf, redirect_stdout(buf):
+        func(**DUMMY_JOB_K_ARGS)
+        stdout: str = buf.getvalue()
+    stdout_lines = stdout.split("\n")
+    assert stdout_lines == [
+        "dummy job function no params",
+        "",
+    ]

--- a/tests/test_job_runner_simple_command.py
+++ b/tests/test_job_runner_simple_command.py
@@ -8,7 +8,7 @@ from runem.config_metadata import ConfigMetadata
 from runem.job import Job
 from runem.job_runner_simple_command import job_runner_simple_command
 from runem.types.runem_config import JobConfig
-from tests.test_runem import gen_dummy_config_metadata
+from tests.utils.gen_dummy_config_metadata import gen_dummy_config_metadata
 
 
 @patch(

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -20,7 +20,6 @@ import pytest
 from runem.config_metadata import ConfigMetadata
 from runem.informative_dict import InformativeDict
 from runem.runem import (
-    MainReturnType,
     _main,
     _process_jobs,
     _process_jobs_by_phase,
@@ -43,6 +42,7 @@ from runem.types.runem_config import (
 from runem.types.types_jobs import JobReturn, JobTiming
 from tests.intentional_test_error import IntentionalTestError
 from tests.sanitise_reports_footer import sanitise_reports_footer
+from tests.utils.dummy_data import DUMMY_MAIN_RETURN
 
 DIR_REPLACEMENT_DIR: str = "[TEST_REPLACED_DIR]"
 
@@ -1814,41 +1814,6 @@ def test_progress_updater_with_false(show_spinner: bool) -> None:
             1,
             show_spinner=show_spinner,
         )
-
-
-def gen_dummy_config_metadata() -> ConfigMetadata:
-    config_metadata: ConfigMetadata = ConfigMetadata(
-        cfg_filepath=pathlib.Path(__file__),
-        phases=("dummy phase 1",),
-        options_config=tuple(),
-        file_filters={
-            "dummy tag": {
-                "tag": "dummy tag",
-                "regex": ".*1.txt",  # should match just one file
-            }
-        },
-        hook_manager=MagicMock(),
-        jobs=defaultdict(list),
-        all_job_names=set(),
-        all_job_phases=set(),
-        all_job_tags=set(),
-    )
-    config_metadata.set_cli_data(
-        args=Namespace(verbose=False, procs=1),
-        jobs_to_run=set(),  # JobNames,
-        phases_to_run=set(),  # JobPhases,
-        tags_to_run=set(),  # ignored JobTags,
-        tags_to_avoid=set(),  # ignored  JobTags,
-        options=InformativeDict({"option_on": True, "option_off": False}),  # Options,
-    )
-    return config_metadata
-
-
-DUMMY_MAIN_RETURN: MainReturnType = (
-    gen_dummy_config_metadata(),  # ConfigMetadata,
-    {},  # job_run_metadatas,
-    IntentionalTestError(),
-)
 
 
 @patch(

--- a/tests/utils/dummy_data.py
+++ b/tests/utils/dummy_data.py
@@ -1,0 +1,64 @@
+"""Dummy data utils for tests."""
+
+import pathlib
+from datetime import timedelta
+
+from runem.config_metadata import ConfigMetadata
+from runem.informative_dict import ReadOnlyInformativeDict
+from runem.job import Job
+from runem.runem import (
+    MainReturnType,
+)
+from runem.types.runem_config import JobConfig
+from runem.types.types_jobs import JobKwargs
+from tests.intentional_test_error import IntentionalTestError
+from tests.utils.gen_dummy_config_metadata import gen_dummy_config_metadata
+
+DUMMY_JOB_CONFIG: JobConfig = {
+    "addr": {
+        "file": __file__,
+        "function": "test_parse_job_config",
+    },
+    "label": "reformat py",
+    "when": {
+        "phase": "edit",
+        "tags": set(
+            (
+                "py",
+                "format",
+            )
+        ),
+    },
+}
+
+DUMMY_MAIN_RETURN: MainReturnType = (
+    gen_dummy_config_metadata(),  # ConfigMetadata,
+    {},  # job_run_metadatas,
+    IntentionalTestError(),
+)
+DUMMY_CONFIG_METADATA: ConfigMetadata = gen_dummy_config_metadata()
+
+
+def do_nothing_record_sub_job_time(
+    label: str,
+    timing: timedelta,
+) -> None:  # pragma: no cover
+    """A `record_sub_job_time` function that does nothing for testing."""
+    pass
+
+
+TESTS_ROOT_PATH: pathlib.Path = pathlib.Path(__file__).parent  # <checkout>/tests
+
+DUMMY_JOB_K_ARGS: JobKwargs = {
+    "config_metadata": DUMMY_CONFIG_METADATA,
+    "file_list": [
+        __file__,
+    ],
+    "job": DUMMY_JOB_CONFIG,
+    "label": Job.get_job_name(DUMMY_JOB_CONFIG),
+    "options": ReadOnlyInformativeDict(DUMMY_CONFIG_METADATA.options),
+    "procs": DUMMY_CONFIG_METADATA.args.procs,
+    "record_sub_job_time": do_nothing_record_sub_job_time,
+    "root_path": TESTS_ROOT_PATH,
+    "verbose": False,
+}

--- a/tests/utils/gen_dummy_config_metadata.py
+++ b/tests/utils/gen_dummy_config_metadata.py
@@ -1,0 +1,35 @@
+import pathlib
+from argparse import Namespace
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+from runem.config_metadata import ConfigMetadata
+from runem.informative_dict import InformativeDict
+
+
+def gen_dummy_config_metadata() -> ConfigMetadata:
+    config_metadata: ConfigMetadata = ConfigMetadata(
+        cfg_filepath=pathlib.Path(__file__),
+        phases=("dummy phase 1",),
+        options_config=tuple(),
+        file_filters={
+            "dummy tag": {
+                "tag": "dummy tag",
+                "regex": ".*1.txt",  # should match just one file
+            }
+        },
+        hook_manager=MagicMock(),
+        jobs=defaultdict(list),
+        all_job_names=set(),
+        all_job_phases=set(),
+        all_job_tags=set(),
+    )
+    config_metadata.set_cli_data(
+        args=Namespace(verbose=False, procs=1),
+        jobs_to_run=set(),  # JobNames,
+        phases_to_run=set(),  # JobPhases,
+        tags_to_run=set(),  # ignored JobTags,
+        tags_to_avoid=set(),  # ignored  JobTags,
+        options=InformativeDict({"option_on": True, "option_off": False}),  # Options,
+    )
+    return config_metadata


### PR DESCRIPTION
### Summary :memo:

Adds `module: path.to.file.then.runem_function`, allowing runtime-loading of shared module in a porject

### Details

Sometime we need the runem jobs to do complex things inside a project. We can do this in one of two ways, call and external tool and allow it to parse errors and so on for runem, or just run the python tool directly, capturing all the nice formatting at so on.

This allows the latter. So now we can load and execute a python function from inside a module anywhere that `runem` itself can import the module from, giving us greater context of the runtime.

Additionally, if we're using runem's own run_command tools to execute tools, we get prettier error messages and timing reports for those jobs, which is nicer.
