### PR TITLE
Fix/module job paths

### DIFF
--- a/runem/job_runner_module_func_path.py
+++ b/runem/job_runner_module_func_path.py
@@ -22,10 +22,10 @@ def _load_python_function_from_dotted_path(
     Raises:
             FunctionNotFound: If the module cannot be imported or the attribute is
                               missing/not callable.
-    z
-        Example:
-            >>> fn = _load_python_function_from_dotted_path(Path('cfg.yml'), 'my_mod.tasks.run')
-            >>> fn()  # call it
+
+    Example:
+        >>> fn = _load_python_function_from_dotted_path(Path('cfg.yml'), 'my_mod.tasks.run')
+        >>> fn()  # call it
     """
     mod_path, sep, func_name = module_func_path.rpartition(".")
     if not sep or not mod_path or not func_name:

--- a/runem/job_runner_module_func_path.py
+++ b/runem/job_runner_module_func_path.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import pathlib
 
 from runem.types.errors import FunctionNotFound
@@ -36,18 +37,35 @@ def _load_python_function_from_dotted_path(
 
     try:
         module = importlib.import_module(mod_path)
-    except Exception as err:  # pylint: disable=broad-except
+    except (  # noqa: B014
+        ModuleNotFoundError,  # known/seen error
+        Exception,  # We do not yet know the full range of exceptions, for now
+    ) as err:  # pylint: disable=broad-except
+        indented_orig_err: str = str(err).replace("\n", "\n\t")
         raise FunctionNotFound(
-            f"Unable to import module '{mod_path}' from dotted path '{module_func_path}'. "
-            f"Check PYTHONPATH and installed packages; config at '{cfg_filepath}'."
+            f"Unable to import module '{mod_path}' from dotted path "
+            f"'{module_func_path}'. \n"
+            f"Check the PYTHONPATH and installed packages; "
+            f"\n\tconfig at '{cfg_filepath}'"
+            f"\n\tcwd is {pathlib.Path.cwd()}"
+            f"\n\tPYTHONPATH is '{os.environ.get('PYTHONPATH', '')}'"
+            "\nOriginal error is:"
+            f"\n\t{indented_orig_err}"
+            "\nIn your cwd try:"
+            f'\n\tpython3 -c "import {mod_path}"'
         ) from err
 
     try:
         func: JobFunction = getattr(module, func_name)
     except AttributeError as err:
         raise FunctionNotFound(
-            f"Function '{func_name}' not found in module '{mod_path}'. "
-            f"Confirm it exists and is exported; config '{cfg_filepath}'."
+            f"Function '{func_name}' not found in module '{mod_path}'."
+            f"Confirm it exists and is exported, checking the job's `cwd`; "
+            f"\n\tconfig at '{cfg_filepath}'\n\tcwd is {pathlib.Path.cwd()}\n"
+            f"\n\tcwd is {pathlib.Path.cwd()}"
+            f"\n\tPYTHONPATH is '{os.environ.get('PYTHONPATH', '')}'"
+            "\nIn your cwd try:"
+            f'\n\tpython3 -c "from {mod_path} import {func_name}"'
         ) from err
 
     if not callable(func):
@@ -72,11 +90,12 @@ def get_job_wrapper_py_module_dot_path(
             cfg_filepath, function_path_to_load
         )
     except FunctionNotFound as err:
-        raise FunctionNotFound(
-            (
-                "runem failed to find "
-                f"job.module '{job_wrapper['module']}' from '{cfg_filepath}'"
-            )
-        ) from err
+        err_message: str = (
+            "runem failed to find "
+            f"job.module '{job_wrapper['module']}' from '{cfg_filepath}'\n"
+            "Original error is:\n"
+            f"{str(err)}"
+        )
+        raise FunctionNotFound(err_message) from err
 
     return function

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -43,6 +43,7 @@ from tests.intentional_test_error import IntentionalTestError
 from tests.sanitise_reports_footer import sanitise_reports_footer
 from tests.utils.dummy_data import (
     DUMMY_FULL_CONFIG_TYPICAL,
+    DUMMY_JOB_S_CONFIG_4_MODULE,
     DUMMY_JOB_S_CONFIG_MINIMAL_COMMAND,
     DUMMY_MAIN_RETURN,
 )
@@ -228,6 +229,7 @@ def _run_full_config_runem(
     add_verbose_switch: bool = True,
     add_silent_switch: bool = False,
     inject_job_minimal_command: bool = True,
+    inject_job_module_config: bool = False,
 ) -> typing.Tuple[typing.List[str], typing.Optional[BaseException]]:
     """A wrapper around running runem e2e tests.
 
@@ -244,6 +246,11 @@ def _run_full_config_runem(
         full_config.append(
             copy.deepcopy(DUMMY_JOB_S_CONFIG_MINIMAL_COMMAND),
         )
+    if inject_job_module_config:
+        full_config.append(
+            copy.deepcopy(DUMMY_JOB_S_CONFIG_4_MODULE),
+        )
+
     minimal_file_lists = defaultdict(list)
     minimal_file_lists["mock phase"].append(pathlib.Path("/test") / "dummy" / "path")
     mocked_config_path = pathlib.Path(__file__).parent / ".runem.yml"
@@ -403,7 +410,8 @@ def test_runem_with_full_config_verbose() -> None:
         runem_stdout,
         error_raised,
     ) = _run_full_config_runem(  # pylint: disable=no-value-for-parameter
-        runem_cli_switches=runem_cli_switches
+        runem_cli_switches=runem_cli_switches,
+        inject_job_module_config=True,
     )
     if error_raised is not None:  # pragma: no cover
         raise error_raised  # re-raise the error that shouldn't have been raised
@@ -431,16 +439,25 @@ def test_runem_with_full_config_verbose() -> None:
         "runem: found 1 batches, 1 'mock phase' files, ",
         (
             "runem: filtering for tags 'dummy tag 1', 'dummy tag 2', "
-            "'tag only on job 1', 'tag only on job 2'"
+            "'tag only on job 1', 'tag only on job 2', 'tag only on job 4'"
         ),
         "runem: will run 2 jobs for phase 'dummy phase 1'",
         "runem:  'dummy job label 1', 'echo \"hello world!\"'",
-        "runem: will run 2 jobs for phase 'dummy phase 2'",
-        "runem:  'dummy job label 2', 'hello world'",
+        "runem: will run 3 jobs for phase 'dummy phase 2'",
+        (
+            "runem:  'dummy job label 2', 'dummy job label 4 (module fn "
+            "lookup)', 'hello world'"
+        ),
         "runem: Running Phase dummy phase 1",
-        "runem: Running 'dummy phase 1' with 2 workers (of [NUM CORES] max) processing 2 jobs",
+        (
+            "runem: Running 'dummy phase 1' with 2 workers (of [NUM CORES] max) "
+            "processing 2 jobs"
+        ),
         "runem: Running Phase dummy phase 2",
-        "runem: Running 'dummy phase 2' with 2 workers (of [NUM CORES] max) processing 2 jobs",
+        (
+            "runem: Running 'dummy phase 2' with 3 workers (of [NUM CORES] max) "
+            "processing 3 jobs"
+        ),
     ]
 
 

--- a/tests/test_runem.py
+++ b/tests/test_runem.py
@@ -217,10 +217,10 @@ MOCK_USER_CONFIGS_METADATA: UserConfigMetadata = [
     return_value=MOCK_JOB_EXECUTE_INNER_RET,
 )
 def _run_full_config_runem(
-    job_runner_mock: Mock,
+    job_execute_inner_mock: Mock,
     find_files_mock: Mock,
-    load_config_mock: Mock,
-    load_config_metadata_mock: Mock,
+    load_project_config_mock: Mock,
+    load_user_configs_metadata_mock: Mock,
     runem_cli_switches: typing.List[str],
     add_verbose_switch: bool = True,
     add_silent_switch: bool = False,
@@ -335,7 +335,7 @@ def _run_full_config_runem(
     minimal_file_lists = defaultdict(list)
     minimal_file_lists["mock phase"].append(pathlib.Path("/test") / "dummy" / "path")
     mocked_config_path = pathlib.Path(__file__).parent / ".runem.yml"
-    load_config_mock.return_value = (full_config, mocked_config_path)
+    load_project_config_mock.return_value = (full_config, mocked_config_path)
     find_files_mock.return_value = minimal_file_lists
     error_raised: typing.Optional[BaseException] = None
     argv: typing.List[str] = [
@@ -359,7 +359,7 @@ def _run_full_config_runem(
         # replace the config path as it's different on different systems
         runem_stdout.replace(str(mocked_config_path), "[CONFIG PATH]")
     ).split("\n")
-    # job_runner_mock.assert_called()
+    # job_execute_inner_mock.assert_called()
     got_to_reports: typing.Optional[int] = None
     try:
         got_to_reports = runem_stdout_lines.index("runem: reports:")

--- a/tests/utils/dummy_data.py
+++ b/tests/utils/dummy_data.py
@@ -3,40 +3,23 @@
 import pathlib
 from datetime import timedelta
 
+from typing_extensions import Unpack
+
 from runem.config_metadata import ConfigMetadata
 from runem.informative_dict import ReadOnlyInformativeDict
 from runem.job import Job
 from runem.runem import (
     MainReturnType,
 )
-from runem.types.runem_config import JobConfig
+from runem.types.runem_config import (
+    Config,
+    GlobalSerialisedConfig,
+    JobConfig,
+    JobSerialisedConfig,
+)
 from runem.types.types_jobs import JobKwargs
 from tests.intentional_test_error import IntentionalTestError
 from tests.utils.gen_dummy_config_metadata import gen_dummy_config_metadata
-
-DUMMY_JOB_CONFIG: JobConfig = {
-    "addr": {
-        "file": __file__,
-        "function": "test_parse_job_config",
-    },
-    "label": "reformat py",
-    "when": {
-        "phase": "edit",
-        "tags": set(
-            (
-                "py",
-                "format",
-            )
-        ),
-    },
-}
-
-DUMMY_MAIN_RETURN: MainReturnType = (
-    gen_dummy_config_metadata(),  # ConfigMetadata,
-    {},  # job_run_metadatas,
-    IntentionalTestError(),
-)
-DUMMY_CONFIG_METADATA: ConfigMetadata = gen_dummy_config_metadata()
 
 
 def do_nothing_record_sub_job_time(
@@ -47,6 +30,142 @@ def do_nothing_record_sub_job_time(
     pass
 
 
+def dummy_job_print_dummy_job(
+    **kwargs: Unpack[JobKwargs],
+) -> None:  # pragma: no cover
+    """A simple job-fn that just prints 'dummy job' to stdout."""
+    print("dummy job")
+
+
+DUMMY_JOB_CONFIG_ADDR: JobConfig = {
+    "addr": {
+        "file": __file__,
+        "function": "dummy_job_print_dummy_job",
+    },
+    "label": "dummy job config with addr, label and when (phase and tags)",
+    "when": {
+        "phase": "dummy phase 1",
+        "tags": set(
+            (
+                "dummy tag 1",
+                "dummy tag 2",
+            )
+        ),
+    },
+}
+
+# Serialised job-config
+DUMMY_GLOBAL_S_CONFIG: GlobalSerialisedConfig = {
+    "config": {
+        "phases": ("dummy phase 1", "dummy phase 2"),
+        "files": [],
+        "min_version": None,
+        "options": [
+            {
+                "option": {
+                    "default": True,
+                    "desc": "a dummy option description",
+                    "aliases": [
+                        "dummy option 1 multi alias 1",
+                        "dummy option 1 multi alias 2",
+                        "x",
+                    ],
+                    "alias": "dummy option alias 1",
+                    "name": "dummy option 1 - complete option",
+                    "type": "bool",
+                }
+            },
+            {
+                "option": {
+                    "default": True,
+                    "name": "dummy option 2 - minimal",
+                    "type": "bool",
+                }
+            },
+        ],
+    }
+}
+
+# Numbered job configs
+DUMMY_JOB_S_CONFIG_1: JobSerialisedConfig = {
+    "job": {
+        "addr": {
+            "file": __file__,
+            "function": "dummy_job_print_dummy_job",
+        },
+        "label": "dummy job label 1",
+        "when": {
+            "phase": "dummy phase 1",
+            "tags": set(
+                (
+                    "dummy tag 1",
+                    "dummy tag 2",
+                    "tag only on job 1",
+                )
+            ),
+        },
+    }
+}
+DUMMY_JOB_S_CONFIG_2: JobSerialisedConfig = {
+    "job": {
+        "addr": {
+            "file": __file__,
+            "function": "dummy_job_print_dummy_job",
+        },
+        "label": "dummy job label 2",
+        "when": {
+            "phase": "dummy phase 2",
+            "tags": set(
+                (
+                    "dummy tag 1",
+                    "dummy tag 2",
+                    "tag only on job 2",
+                )
+            ),
+        },
+    }
+}
+
+# Same as a above but with minimal data, bare bones, as the docs describe
+DUMMY_JOB_S_CONFIG_MINIMAL_COMMAND: JobSerialisedConfig = {
+    "job": {
+        "command": 'echo "hello world!"',
+    }
+}
+
+# A simple command serialised config
+DUMMY_JOB_S_CONFIG_COMMAND: JobSerialisedConfig = {
+    "job": {
+        "command": 'echo "hello world!"',
+        "label": "hello world",
+        "when": {
+            "phase": "dummy phase 2",
+            "tags": set(
+                (
+                    "dummy tag 1",
+                    "dummy tag 2",
+                )
+            ),
+        },
+    }
+}
+DUMMY_FULL_CONFIG_TYPICAL: Config = [
+    # Global Config first
+    DUMMY_GLOBAL_S_CONFIG,
+    # N-jobs
+    DUMMY_JOB_S_CONFIG_1,
+    DUMMY_JOB_S_CONFIG_2,
+    DUMMY_JOB_S_CONFIG_COMMAND,
+]
+
+DUMMY_MAIN_RETURN: MainReturnType = (
+    gen_dummy_config_metadata(),  # ConfigMetadata,
+    {},  # job_run_metadatas,
+    IntentionalTestError(),
+)
+DUMMY_CONFIG_METADATA: ConfigMetadata = gen_dummy_config_metadata()
+
+
 TESTS_ROOT_PATH: pathlib.Path = pathlib.Path(__file__).parent  # <checkout>/tests
 
 DUMMY_JOB_K_ARGS: JobKwargs = {
@@ -54,8 +173,8 @@ DUMMY_JOB_K_ARGS: JobKwargs = {
     "file_list": [
         __file__,
     ],
-    "job": DUMMY_JOB_CONFIG,
-    "label": Job.get_job_name(DUMMY_JOB_CONFIG),
+    "job": DUMMY_JOB_CONFIG_ADDR,
+    "label": Job.get_job_name(DUMMY_JOB_CONFIG_ADDR),
     "options": ReadOnlyInformativeDict(DUMMY_CONFIG_METADATA.options),
     "procs": DUMMY_CONFIG_METADATA.args.procs,
     "record_sub_job_time": do_nothing_record_sub_job_time,

--- a/tests/utils/dummy_data.py
+++ b/tests/utils/dummy_data.py
@@ -57,7 +57,10 @@ DUMMY_JOB_CONFIG_ADDR: JobConfig = {
 # Serialised job-config
 DUMMY_GLOBAL_S_CONFIG: GlobalSerialisedConfig = {
     "config": {
-        "phases": ("dummy phase 1", "dummy phase 2"),
+        "phases": (
+            "dummy phase 1",
+            "dummy phase 2",
+        ),
         "files": [],
         "min_version": None,
         "options": [
@@ -87,7 +90,7 @@ DUMMY_GLOBAL_S_CONFIG: GlobalSerialisedConfig = {
 }
 
 # Numbered job configs
-DUMMY_JOB_S_CONFIG_1: JobSerialisedConfig = {
+DUMMY_JOB_S_CONFIG_1_ADDR: JobSerialisedConfig = {
     "job": {
         "addr": {
             "file": __file__,
@@ -106,7 +109,7 @@ DUMMY_JOB_S_CONFIG_1: JobSerialisedConfig = {
         },
     }
 }
-DUMMY_JOB_S_CONFIG_2: JobSerialisedConfig = {
+DUMMY_JOB_S_CONFIG_2_ADDR: JobSerialisedConfig = {
     "job": {
         "addr": {
             "file": __file__,
@@ -125,16 +128,8 @@ DUMMY_JOB_S_CONFIG_2: JobSerialisedConfig = {
         },
     }
 }
-
-# Same as a above but with minimal data, bare bones, as the docs describe
-DUMMY_JOB_S_CONFIG_MINIMAL_COMMAND: JobSerialisedConfig = {
-    "job": {
-        "command": 'echo "hello world!"',
-    }
-}
-
 # A simple command serialised config
-DUMMY_JOB_S_CONFIG_COMMAND: JobSerialisedConfig = {
+DUMMY_JOB_S_CONFIG_3_COMMAND: JobSerialisedConfig = {
     "job": {
         "command": 'echo "hello world!"',
         "label": "hello world",
@@ -149,13 +144,39 @@ DUMMY_JOB_S_CONFIG_COMMAND: JobSerialisedConfig = {
         },
     }
 }
+# A simple module serialised config
+DUMMY_JOB_S_CONFIG_4_MODULE: JobSerialisedConfig = {
+    "job": {
+        "module": "tests.utils.dummy_data.dummy_job_print_dummy_job",
+        "label": "dummy job label 4 (module fn lookup)",
+        "when": {
+            "phase": "dummy phase 2",
+            "tags": set(
+                (
+                    "dummy tag 1",
+                    "dummy tag 2",
+                    "tag only on job 4",
+                )
+            ),
+        },
+    }
+}
+
+# Same as DUMMY_JOB_S_CONFIG_3_COMMAND but with minimal data, bare bones, as the docs describe
+DUMMY_JOB_S_CONFIG_MINIMAL_COMMAND: JobSerialisedConfig = {
+    "job": {
+        "command": 'echo "hello world!"',
+    }
+}
+
+# A full runem config
 DUMMY_FULL_CONFIG_TYPICAL: Config = [
     # Global Config first
     DUMMY_GLOBAL_S_CONFIG,
     # N-jobs
-    DUMMY_JOB_S_CONFIG_1,
-    DUMMY_JOB_S_CONFIG_2,
-    DUMMY_JOB_S_CONFIG_COMMAND,
+    DUMMY_JOB_S_CONFIG_1_ADDR,
+    DUMMY_JOB_S_CONFIG_2_ADDR,
+    DUMMY_JOB_S_CONFIG_3_COMMAND,
 ]
 
 DUMMY_MAIN_RETURN: MainReturnType = (


### PR DESCRIPTION
### Summary :memo:

Fixes `module` job specs not working when runem is installed

### Details

The new `module` feature of runem was not working when using the runem library.

This adds the `.runem.yml` dir-path to the `sys.path` as one solution. At somepoint we might want to do something a bit more refined.

This shows an oversight in the e2e testing of runem, which we don't fix in this commit.
